### PR TITLE
ci: bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -22,7 +22,7 @@ jobs:
       url: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Compute preview metadata
         id: ver
@@ -54,14 +54,14 @@ jobs:
 
       - name: Deploy to Cloudflare Pages (preview)
         id: deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy dist --project-name=ugas --branch=${{ steps.ver.outputs.branch }}
 
       - name: Post preview URL as PR comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         if: github.event_name == 'pull_request'
         with:
           script: |

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,12 +22,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: source
 
       - name: Checkout docs branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: docs
           path: docs

--- a/.github/workflows/validate-schema-examples.yml
+++ b/.github/workflows/validate-schema-examples.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## Summary
Bump the GitHub Actions used by the existing workflows to their latest major versions:

- `actions/checkout` v4 -> v6 (preview-docs, publish-docs, validate-schema-examples)
- `actions/setup-python` v5 -> v6 (validate-schema-examples)
- `actions/github-script` v7 -> v9 (preview-docs)
- `cloudflare/wrangler-action` v3 -> v4 (preview-docs)

`changesets/action` is already on the latest major (v1). `version.yml` (introduced in #23) is bumped on that branch.

## Test plan
- [x] `validate-schema-examples` runs green on push
- [x] `preview-docs` builds and deploys a Cloudflare Pages preview, and the PR comment posts
- [x] `publish-docs` checkout steps work on next release