### PR TITLE
ci: add LLM discoverability files

### DIFF
--- a/.changeset/llm-discoverability.md
+++ b/.changeset/llm-discoverability.md
@@ -1,0 +1,5 @@
+---
+'ugas': patch
+---
+
+[Added] LLM discoverability: `llms.txt`, `SPEC.md` (Markdown via Pandoc), and `llms-full.txt` (complete spec + schemas + examples) generated in CI and published alongside HTML docs

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -36,14 +36,19 @@ jobs:
             echo "branch=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Resolve version placeholders in schemas
+      - name: Resolve version placeholders
         run: |
           find schemas -type f \( -name '*.json' -o -name '*.yaml' -o -name '*.md' \) \
             -exec sed -i "s/%%UGAS_VERSION%%/${{ steps.ver.outputs.version }}/g" {} +
+          sed -i "s/%%UGAS_VERSION%%/${{ steps.ver.outputs.version }}/g" llms.txt
+
+      - name: Install Asciidoctor and Pandoc
+        run: |
+          sudo gem install asciidoctor
+          sudo apt-get update -qq && sudo apt-get install -y -qq pandoc
 
       - name: Build SPEC.adoc with AsciiDoctor
         run: |
-          sudo gem install asciidoctor
           mkdir -p dist
           asciidoctor \
             -a revnumber="${{ steps.ver.outputs.version }}" \
@@ -51,6 +56,11 @@ jobs:
             -a stem=latexmath \
             SPEC.adoc \
             -o dist/index.html
+
+      - name: Generate LLM files
+        run: |
+          bash scripts/generate-llm-files.sh . dist "${{ steps.ver.outputs.version }}"
+          cp llms.txt dist/llms.txt
 
       - name: Deploy to Cloudflare Pages (preview)
         id: deploy

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -49,15 +49,20 @@ jobs:
 
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Resolve version placeholders in schemas
+      - name: Resolve version placeholders
         run: |
           VERSION="v${{ steps.version.outputs.version }}"
           find source/schemas -type f \( -name '*.json' -o -name '*.yaml' -o -name '*.md' \) \
             -exec sed -i "s/%%UGAS_VERSION%%/${VERSION}/g" {} +
+          sed -i "s/%%UGAS_VERSION%%/${VERSION}/g" source/llms.txt
+
+      - name: Install Asciidoctor and Pandoc
+        run: |
+          sudo gem install asciidoctor
+          sudo apt-get update -qq && sudo apt-get install -y -qq pandoc
 
       - name: Build SPEC.adoc with AsciiDoctor
         run: |
-          sudo gem install asciidoctor
           asciidoctor \
             -a revnumber="${{ steps.version.outputs.version }}" \
             -a ugas-version="v${{ steps.version.outputs.version }}" \
@@ -65,14 +70,55 @@ jobs:
             source/SPEC.adoc \
             -o source/index.html
 
+      - name: Generate LLM files
+        run: |
+          bash source/scripts/generate-llm-files.sh source source "v${{ steps.version.outputs.version }}"
+
       - name: Copy files to docs branch
         run: |
-          DEST="docs/v${{ steps.version.outputs.version }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          DEST="docs/v${VERSION}"
           mkdir -p "${DEST}/schemas"
           cp -r source/schemas/* "${DEST}/schemas/"
           cp source/SPEC.adoc "${DEST}/SPEC.adoc"
           cp -r source/spec "${DEST}/spec"
           cp source/index.html "${DEST}/index.html"
+          cp source/SPEC.md "${DEST}/SPEC.md"
+          cp source/llms.txt docs/llms.txt
+          cp source/llms-full.txt docs/llms-full.txt
+
+      - name: Update README version table
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          DATE="$(date -u +%Y-%m-%d)"
+
+          # Seed the marker if the README doesn't have one yet (one-time migration)
+          if ! grep -q '<!-- NEW_VERSION -->' docs/README.md; then
+          cat > docs/README.md <<'EOF'
+          # Universal Gameplay Ability System (UGAS)
+
+          > An open, engine-agnostic specification for standardizing gameplay logic across game engines and AI world models.
+
+          ## Published Versions
+
+          | Version | Date | Status | Specification | Schemas |
+          |---------|------|--------|---------------|---------|
+          <!-- NEW_VERSION -->
+
+          ## About
+
+          UGAS defines a unified architecture for gameplay abilities, attributes, effects, and state management that works across traditional game engines (Unreal, Unity, Godot) and AI world models.
+
+          For the full project overview, source code, and contribution guidelines, see the [main repository](https://github.com/jbltx/ugas).
+          EOF
+          fi
+
+          if grep -qF "[v${VERSION}]" docs/README.md; then
+            echo "Version v${VERSION} already in README, skipping"
+          else
+            ROW="| [v${VERSION}](v${VERSION}/) | ${DATE} | Pre-release | [Spec](v${VERSION}/index.html) · [MD](v${VERSION}/SPEC.md) | [Schemas](v${VERSION}/schemas/) |"
+            sed -i "s|<!-- NEW_VERSION -->|${ROW}\n<!-- NEW_VERSION -->|" docs/README.md
+          fi
 
       - name: Create PR to docs branch
         env:
@@ -103,5 +149,8 @@ jobs:
 
           - \`SPEC.adoc\` → \`v${VERSION}/SPEC.adoc\`
           - \`SPEC.adoc\` → \`v${VERSION}/index.html\` (HTML with AsciiDoctor)
-          - \`schemas/**/*\` → \`v${VERSION}/schemas/\`"
+          - \`SPEC.adoc\` → \`v${VERSION}/SPEC.md\` (Markdown via Pandoc)
+          - \`schemas/**/*\` → \`v${VERSION}/schemas/\`
+          - \`llms.txt\` → root (LLM discoverability)
+          - \`llms-full.txt\` → root (complete LLM context)"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ __pycache__/
 *.pyc
 .DS_Store
 node_modules/
+
+# Generated LLM files
+SPEC.md
+SPEC.xml
+llms-full.txt

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,32 @@
+# Universal Gameplay Ability System (UGAS)
+
+> UGAS is an open, engine-agnostic specification for standardizing gameplay abilities, attributes, effects, and tags across game engines (Unreal, Unity, Godot) and AI world models. It defines a portable, data-driven architecture for gameplay logic.
+
+The specification covers four pillars: Attributes (numeric state with a modifier pipeline), Gameplay Tags (hierarchical semantic labels), Gameplay Abilities (asynchronous stateful actions), and Gameplay Effects (the sole mutation mechanism for attributes and tags).
+
+## Specification
+
+- [UGAS Specification (Markdown)](%%UGAS_VERSION%%/SPEC.md): The full technical specification in Markdown format
+- [UGAS Specification (HTML)](%%UGAS_VERSION%%/index.html): The full technical specification rendered as HTML
+- [UGAS Specification (AsciiDoc)](%%UGAS_VERSION%%/SPEC.adoc): The full technical specification in AsciiDoc source format
+- [Complete LLM context file](llms-full.txt): The entire specification plus all schema definitions and examples in a single file
+
+## Schema Definitions
+
+- [Gameplay Controller Schema](%%UGAS_VERSION%%/schemas/gameplay_controller.yaml): Central hub managing abilities, effects, attributes, and tags
+- [Attribute Schema](%%UGAS_VERSION%%/schemas/attribute.yaml): Individual attribute definitions with base values, clamping, replication
+- [Attribute Set Schema](%%UGAS_VERSION%%/schemas/attribute_set.yaml): Logical groupings of related attributes
+- [Gameplay Effect Schema](%%UGAS_VERSION%%/schemas/gameplay_effect.yaml): Effects that modify attributes and grant tags/abilities
+- [Gameplay Ability Schema](%%UGAS_VERSION%%/schemas/gameplay_ability.yaml): Ability definitions with tag-based activation rules
+- [Gameplay Tag Schema](%%UGAS_VERSION%%/schemas/gameplay_tag.yaml): Tag registry for hierarchical semantic state labels
+
+## Examples
+
+- [Health Attribute](%%UGAS_VERSION%%/schemas/examples/health_attribute.yaml): Resource attribute with clamping
+- [Damage Effect](%%UGAS_VERSION%%/schemas/examples/damage_effect.yaml): Instant effect that modifies Health
+- [Fireball Ability](%%UGAS_VERSION%%/schemas/examples/fireball_ability.yaml): Offensive ability with tag requirements
+- [Tag Registry](%%UGAS_VERSION%%/schemas/examples/tag_registry.yaml): Example tag hierarchy
+
+## Optional
+
+- [Schema README](%%UGAS_VERSION%%/schemas/README.md): Documentation for schema usage and validation

--- a/scripts/generate-llm-files.sh
+++ b/scripts/generate-llm-files.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Generate SPEC.md and llms-full.txt from SPEC.adoc.
+#
+# Prerequisites: asciidoctor, pandoc
+#
+# Usage:
+#   ./scripts/generate-llm-files.sh <source-dir> <output-dir> <version>
+#
+set -euo pipefail
+
+SOURCE_DIR="${1:?Usage: $0 <source-dir> <output-dir> <version>}"
+OUTPUT_DIR="${2:?Usage: $0 <source-dir> <output-dir> <version>}"
+VERSION="${3:?Usage: $0 <source-dir> <output-dir> <version>}"
+
+mkdir -p "${OUTPUT_DIR}"
+
+# AsciiDoc → DocBook XML (resolves all include:: directives)
+asciidoctor \
+  -b docbook \
+  -a revnumber="${VERSION#v}" \
+  -a ugas-version="${VERSION}" \
+  -a stem=latexmath \
+  "${SOURCE_DIR}/SPEC.adoc" \
+  -o "${OUTPUT_DIR}/SPEC.xml"
+
+# DocBook XML → GitHub Flavored Markdown
+# --wrap=none prevents breaking inline math expressions
+pandoc \
+  -f docbook \
+  -t gfm \
+  --wrap=none \
+  "${OUTPUT_DIR}/SPEC.xml" \
+  -o "${OUTPUT_DIR}/SPEC.md"
+
+rm -f "${OUTPUT_DIR}/SPEC.xml"
+
+# Build llms-full.txt: spec + schemas + examples
+cp "${OUTPUT_DIR}/SPEC.md" "${OUTPUT_DIR}/llms-full.txt"
+
+cat >> "${OUTPUT_DIR}/llms-full.txt" <<'HEADER'
+
+---
+
+# Schema Definitions
+
+The following YAML schemas define the data format for each UGAS entity type.
+
+HEADER
+
+for schema_file in "${SOURCE_DIR}"/schemas/*.yaml; do
+  filename="$(basename "${schema_file}")"
+  pretty_name="$(echo "${filename%.yaml}" | tr '_' ' ' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1')"
+  printf '\n## %s Schema\n\n```yaml\n' "${pretty_name}" >> "${OUTPUT_DIR}/llms-full.txt"
+  cat "${schema_file}" >> "${OUTPUT_DIR}/llms-full.txt"
+  printf '```\n' >> "${OUTPUT_DIR}/llms-full.txt"
+done
+
+cat >> "${OUTPUT_DIR}/llms-full.txt" <<'HEADER'
+
+---
+
+# Schema Examples
+
+The following YAML files are concrete examples of UGAS entity definitions.
+
+HEADER
+
+for example_file in "${SOURCE_DIR}"/schemas/examples/*.yaml; do
+  filename="$(basename "${example_file}")"
+  pretty_name="$(echo "${filename%.yaml}" | tr '_' ' ' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1')"
+  printf '\n## Example: %s\n\n```yaml\n' "${pretty_name}" >> "${OUTPUT_DIR}/llms-full.txt"
+  cat "${example_file}" >> "${OUTPUT_DIR}/llms-full.txt"
+  printf '```\n' >> "${OUTPUT_DIR}/llms-full.txt"
+done
+
+echo "Generated: ${OUTPUT_DIR}/SPEC.md"
+echo "Generated: ${OUTPUT_DIR}/llms-full.txt"


### PR DESCRIPTION
## Summary
- Add `llms.txt` at repo root following the [llms.txt standard](https://llmstxt.org/) for LLM/AI agent discoverability
- Add `scripts/generate-llm-files.sh` to convert SPEC.adoc → SPEC.md (via DocBook + Pandoc) and build `llms-full.txt` (spec + all schemas + examples in one file)
- Update `preview-docs.yml` and `publish-docs.yml` to install Pandoc, generate LLM files, and deploy them
- Auto-update the docs branch README version table with date on each release (uses `<!-- NEW_VERSION -->` marker)

## Test plan
- [x] Verify preview workflow runs and deploys `llms.txt`, `SPEC.md`, `llms-full.txt` to Cloudflare Pages
- [x] Verify LaTeX math survives the AsciiDoc → DocBook → Markdown conversion
- [x] Verify `llms-full.txt` contains the full spec followed by all 6 schema definitions and 4 examples