### PR TITLE
feat: genre pack structure (spec + template)

### DIFF
--- a/.changeset/genre-pack-structure.md
+++ b/.changeset/genre-pack-structure.md
@@ -1,0 +1,5 @@
+---
+'ugas': minor
+---
+
+[Added] Genre pack structure: `genres/` directory with a copyable `_template/` skeleton (additional `spec.adoc` + schema-conformant `entities/`) and an authoring/convention guide. Schema validation now scans `genres/`, and the docs workflows build each `genres/<genre>/spec.adoc` to its own page.

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Resolve version placeholders
         run: |
-          find schemas -type f \( -name '*.json' -o -name '*.yaml' -o -name '*.md' \) \
+          find schemas genres -type f \( -name '*.json' -o -name '*.yaml' -o -name '*.md' \) \
             -exec sed -i "s/%%UGAS_VERSION%%/${{ steps.ver.outputs.version }}/g" {} +
           sed -i "s/%%UGAS_VERSION%%/${{ steps.ver.outputs.version }}/g" llms.txt
 
@@ -56,6 +56,20 @@ jobs:
             -a stem=latexmath \
             SPEC.adoc \
             -o dist/index.html
+
+      - name: Build genre packs with AsciiDoctor
+        run: |
+          for spec in genres/*/spec.adoc; do
+            [ -f "$spec" ] || continue
+            genre="$(basename "$(dirname "$spec")")"
+            mkdir -p "dist/genres/${genre}"
+            asciidoctor \
+              -a revnumber="${{ steps.ver.outputs.version }}" \
+              -a ugas-version="${{ steps.ver.outputs.version }}" \
+              -a stem=latexmath \
+              "$spec" \
+              -o "dist/genres/${genre}/index.html"
+          done
 
       - name: Generate LLM files
         run: |

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Resolve version placeholders
         run: |
           VERSION="v${{ steps.version.outputs.version }}"
-          find source/schemas -type f \( -name '*.json' -o -name '*.yaml' -o -name '*.md' \) \
+          find source/schemas source/genres -type f \( -name '*.json' -o -name '*.yaml' -o -name '*.md' \) \
             -exec sed -i "s/%%UGAS_VERSION%%/${VERSION}/g" {} +
           sed -i "s/%%UGAS_VERSION%%/${VERSION}/g" source/llms.txt
 
@@ -70,6 +70,19 @@ jobs:
             source/SPEC.adoc \
             -o source/index.html
 
+      - name: Build genre packs with AsciiDoctor
+        run: |
+          for spec in source/genres/*/spec.adoc; do
+            [ -f "$spec" ] || continue
+            genre="$(basename "$(dirname "$spec")")"
+            asciidoctor \
+              -a revnumber="${{ steps.version.outputs.version }}" \
+              -a ugas-version="v${{ steps.version.outputs.version }}" \
+              -a stem=latexmath \
+              "$spec" \
+              -o "source/genres/${genre}/index.html"
+          done
+
       - name: Generate LLM files
         run: |
           bash source/scripts/generate-llm-files.sh source source "v${{ steps.version.outputs.version }}"
@@ -82,6 +95,7 @@ jobs:
           cp -r source/schemas/* "${DEST}/schemas/"
           cp source/SPEC.adoc "${DEST}/SPEC.adoc"
           cp -r source/spec "${DEST}/spec"
+          [ -d source/genres ] && cp -r source/genres "${DEST}/genres"
           cp source/index.html "${DEST}/index.html"
           cp source/SPEC.md "${DEST}/SPEC.md"
           cp source/llms.txt docs/llms.txt

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ UGAS defines a unified architecture for implementing gameplay abilities, attribu
 | Document           | Description                              |
 |--------------------|------------------------------------------|
 | [SPEC.adoc](SPEC.adoc) | Full technical specification             |
+| [genres/](genres/README.md) | Genre packs: per-genre additional specs + ready-to-use templates |
 
 ## Schema Definitions
 

--- a/genres/README.md
+++ b/genres/README.md
@@ -1,0 +1,56 @@
+# UGAS Genre Packs
+
+The core [UGAS specification](../SPEC.adoc) is deliberately genre-agnostic. A **genre
+pack** makes it practical to bootstrap a real game — by humans or AI agents — by bundling
+two **additive** artifacts per genre:
+
+1. an **additional spec** that extends (never replaces) the core spec with genre-specific
+   Attributes, Tags, Abilities, and Effects; and
+2. a **template**: ready-to-use, schema-conformant entity files.
+
+## Layout contract
+
+Each pack is one self-contained directory under `genres/`, named in kebab-case:
+
+```
+genres/
+  README.md            <- this file (convention + index)
+  _template/           <- copyable skeleton pack
+  <genre>/
+    spec.adoc          <- additional genre spec (extends the core spec)
+    entities/
+      *.yaml           <- template entities, each $schema-tagged with real values
+    README.md          <- what the pack is + how to use it
+```
+
+## Rules
+
+- **Additive only.** A genre `spec.adoc` MUST NOT redefine, override, or contradict any
+  concept in [`SPEC.adoc`](../SPEC.adoc). It only adds genre-specific definitions and links
+  back to core sections.
+- **Entities must validate.** Every `.yaml`/`.json` under `genres/` must be a schema
+  instance carrying a root `$schema` key that ends in one of the six core schemas
+  (e.g. `…/schemas/attribute.json`). Use the version placeholder:
+  `$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/<name>.json`.
+  Only such entity files may live under `genres/` — `scripts/validate_schema_examples.py`
+  validates the whole tree and fails on a missing/unknown `$schema`.
+- **No placeholder scalars.** Use real values; tokens like `string` or `float` fail validation.
+- **Consistent docs.** Reuse the core AsciiDoc header attributes (see `_template/spec.adoc`).
+  Each `spec.adoc` is built to its own `genres/<genre>/index.html` by the docs workflows.
+
+## Authoring a new pack
+
+1. Copy `_template/` to `genres/<your-genre>/`.
+2. Rename and fill in `spec.adoc`, the `entities/`, and `README.md`.
+3. Run `python scripts/validate_schema_examples.py` — it must pass.
+
+## Consuming a pack
+
+Users and AI agents (e.g. the `ugas-schema-author` skill, and the planned gameplay-creator
+assistant skill) can load a pack's `entities/` directly as a starting point and extend them.
+
+## Pack index
+
+| Pack | Status | Spec |
+|------|--------|------|
+| `_template` | Skeleton (reference only) | [`_template/spec.adoc`](_template/spec.adoc) |

--- a/genres/_template/README.md
+++ b/genres/_template/README.md
@@ -1,0 +1,25 @@
+# UGAS Genre Pack: &lt;Genre Name&gt;
+
+> One-line summary of the genre this pack targets.
+
+This is the skeleton genre pack. Copy `genres/_template/` to `genres/<your-genre>/`
+(kebab-case) and replace the contents.
+
+## What's in this pack
+
+| File | Purpose |
+|------|---------|
+| `spec.adoc` | Additional genre specification — extends, never replaces, the core spec |
+| `entities/*.yaml` | Ready-to-use, schema-conformant template entities |
+| `README.md` | This file |
+
+## How to use
+
+1. Read `spec.adoc` for the genre-specific design.
+2. Copy the entity files in `entities/` into your project and adapt them.
+3. They validate against the core `schemas/*.yaml`, so AI agents (e.g. the
+   `ugas-schema-author` skill) can load and extend them directly.
+
+## Published spec
+
+<!-- Link to the built HTML once published, e.g. v<version>/genres/<genre>/index.html -->

--- a/genres/_template/entities/ability.yaml
+++ b/genres/_template/entities/ability.yaml
@@ -1,0 +1,22 @@
+# Template entity: Gameplay Ability
+# Replace with a genre-specific ability (lifecycle: Grant -> TryActivate -> ... -> End).
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
+Name: ExampleAbility
+Tags:
+  AbilityTags:
+    - Ability.Example
+  ActivationRequiredTags:
+    - State.CanAct
+  ActivationBlockedTags:
+    - State.Stunned
+  ActivationOwnedTags:
+    - State.Busy
+Tasks:
+  - Type: PlayMontage
+    Params:
+      MontageToPlay: Anim_Example
+      PlayRate: 1.0
+Metadata:
+  DisplayName: Example Ability
+  Description: Replace with a genre-specific ability definition

--- a/genres/_template/entities/attribute.yaml
+++ b/genres/_template/entities/attribute.yaml
@@ -1,0 +1,16 @@
+# Template entity: Attribute
+# Replace with a genre-specific attribute. Every field below uses a real value
+# (the validator rejects placeholder tokens like "string"/"float").
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/attribute.json
+Name: Health
+DefaultBaseValue: 100.0
+Category: Resource
+Clamping:
+  Min: 0
+  Max: MaxHealth
+ReplicationMode: All
+Metadata:
+  DisplayName: Health Points
+  Description: Example vital resource attribute for this genre pack
+  UICategory: Vital Stats

--- a/genres/_template/entities/effect.yaml
+++ b/genres/_template/entities/effect.yaml
@@ -1,0 +1,14 @@
+# Template entity: Gameplay Effect
+# Replace with a genre-specific effect. The only authorized way to mutate attributes/tags.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: ExampleDamageEffect
+DurationPolicy: Instant
+Modifiers:
+  - Attribute: Health
+    Operation: Add
+    Magnitude:
+      Type: ScalableFloat
+      Value: -10.0
+GrantedTags:
+  - State.Damaged

--- a/genres/_template/entities/tag_registry.yaml
+++ b/genres/_template/entities/tag_registry.yaml
@@ -1,0 +1,24 @@
+# Template entity: Gameplay Tag registry
+# Replace with the hierarchical tags this genre pack introduces.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_tag.json
+Tags:
+  - Tag: State.CanAct
+    Description: Entity is able to act
+    AllowMultiple: false
+
+  - Tag: State.Busy
+    Description: Entity is mid-action
+    AllowMultiple: false
+
+  - Tag: State.Stunned
+    Description: Entity is stunned and cannot act
+    AllowMultiple: false
+
+  - Tag: State.Damaged
+    Description: Entity recently took damage
+    AllowMultiple: false
+
+  - Tag: Ability.Example
+    Description: Example ability classification tag
+    AllowMultiple: true

--- a/genres/_template/spec.adoc
+++ b/genres/_template/spec.adoc
@@ -1,0 +1,61 @@
+= UGAS Genre Pack: <Genre Name>
+Mickael Bonfill <jbltx>
+:revnumber: 1.0.0-draft.1
+:ugas-version: v1.0.0-draft.1
+:doctype: book
+:toc: left
+:toc-title: Table of Contents
+:toclevels: 4
+:stem: latexmath
+:source-highlighter: highlight.js
+:icons: font
+:sectanchors:
+:sectlinks:
+:docinfo: shared
+
+// This is the skeleton for a UGAS "genre pack" additional specification.
+// Copy the genres/_template/ directory to genres/<your-genre>/ and fill it in.
+// A genre pack EXTENDS the core spec — it must never contradict or override it.
+
+[[overview]]
+== Overview
+
+// TODO: One paragraph describing the genre, the kind of games it targets, and
+// which UGAS pillars it leans on most. Link the matching core case study, e.g.
+// the Platformer / Racing / ARPG / Puzzle studies in
+// link:../../SPEC.adoc[the core specification] (Section 15, Case Studies).
+
+[[relationship-to-core-spec]]
+== Relationship to the core specification
+
+This document is *additive*. It defines genre-specific Attributes, Tags, Abilities,
+and Effects on top of the core Universal Gameplay Ability System specification.
+
+* It MUST NOT redefine, override, or contradict any concept in the core spec.
+* All entities in `entities/` validate against the same `schemas/*.yaml` as the core.
+* Refer to the core spec for the four pillars and the Gameplay Controller:
+  link:../../SPEC.adoc[UGAS Specification].
+
+[[genre-attributes]]
+== Genre Attributes
+
+// TODO: Describe the attributes this genre introduces (e.g. movement, resources).
+// Provide the canonical definitions in entities/ (see entities/attribute.yaml).
+
+[[genre-tags]]
+== Genre Tags
+
+// TODO: Describe the gameplay tag hierarchy this genre relies on.
+// Provide the registry in entities/ (see entities/tag_registry.yaml).
+
+[[genre-abilities]]
+== Genre Abilities
+
+// TODO: Describe the signature abilities of this genre and their lifecycles.
+// Provide the definitions in entities/ (see entities/ability.yaml).
+
+[[genre-effects]]
+== Genre Effects
+
+// TODO: Describe the gameplay effects this genre uses to mutate state.
+// Provide the definitions in entities/ (see entities/effect.yaml).

--- a/scripts/validate_schema_examples.py
+++ b/scripts/validate_schema_examples.py
@@ -107,6 +107,51 @@ def validate_document(
         errors.append(f"{source}: {path}: {error.message}")
 
 
+def validate_example_file(
+    path: Path,
+    validators: Dict[str, Draft7Validator],
+    required_fields: Dict[str, List[str]],
+    errors: List[str],
+) -> int:
+    try:
+        if path.suffix.lower() == ".json":
+            docs = [load_json(path)]
+        else:
+            with path.open("r", encoding="utf-8") as handle:
+                docs = list(yaml.safe_load_all(handle))
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"{path}: failed to parse ({exc})")
+        return 0
+
+    validated = 0
+    for index, doc in enumerate(docs, start=1):
+        if doc is None:
+            continue
+        schema_key = schema_key_from_schema_id(doc.get("$schema"))
+        if schema_key is None:
+            errors.append(f"{path}: missing or unknown $schema for document {index}")
+            continue
+
+        payload = {key: value for key, value in doc.items() if key != "$schema"}
+        if schema_key not in validators:
+            errors.append(f"{path}: missing schema for {schema_key}")
+            continue
+
+        if has_placeholder(payload):
+            errors.append(f"{path}: placeholder values found in document {index}")
+            continue
+
+        required = required_fields.get(schema_key, [])
+        if required and not all(key in payload for key in required):
+            errors.append(f"{path}: missing required fields in document {index}")
+            continue
+
+        source = f"{path} (doc {index})"
+        validate_document(validators[schema_key], payload, source, errors)
+        validated += 1
+    return validated
+
+
 def main() -> int:
     root = Path(__file__).resolve().parents[1]
     schemas_root = root / "schemas"
@@ -133,50 +178,17 @@ def main() -> int:
     validated_count = 0
     skipped_spec = 0
 
-    # Validate examples folder
-    examples_root = schemas_root / "examples"
-    if examples_root.exists():
+    # Validate example/template folders: core examples + genre packs
+    example_roots = [schemas_root / "examples", root / "genres"]
+    for examples_root in example_roots:
+        if not examples_root.exists():
+            continue
         for path in sorted(examples_root.rglob("*")):
             if path.suffix.lower() not in {".yaml", ".yml", ".json"}:
                 continue
-            try:
-                if path.suffix.lower() == ".json":
-                    data = load_json(path)
-                    docs = [data]
-                else:
-                    with path.open("r", encoding="utf-8") as handle:
-                        docs = list(yaml.safe_load_all(handle))
-            except Exception as exc:  # noqa: BLE001
-                errors.append(f"{path}: failed to parse ({exc})")
-                continue
-
-            for index, doc in enumerate(docs, start=1):
-                if doc is None:
-                    continue
-                schema_key = schema_key_from_schema_id(doc.get("$schema"))
-                if schema_key is None:
-                    errors.append(
-                        f"{path}: missing or unknown $schema for document {index}"
-                    )
-                    continue
-
-                payload = {key: value for key, value in doc.items() if key != "$schema"}
-                if schema_key not in validators:
-                    errors.append(f"{path}: missing schema for {schema_key}")
-                    continue
-
-                if has_placeholder(payload):
-                    errors.append(f"{path}: placeholder values found in document {index}")
-                    continue
-
-                required = required_fields.get(schema_key, [])
-                if required and not all(key in payload for key in required):
-                    errors.append(f"{path}: missing required fields in document {index}")
-                    continue
-
-                source = f"{path} (doc {index})"
-                validate_document(validators[schema_key], payload, source, errors)
-                validated_count += 1
+            validated_count += validate_example_file(
+                path, validators, required_fields, errors
+            )
 
     # Validate SPEC.md code blocks
     if spec_path.exists():


### PR DESCRIPTION
## Summary

Defines the common **genre pack** structure so per-genre specs + templates (#28) are consistent, auto-validated, and auto-published. Structure only — no real genre content is authored here.

- Adds `genres/` with a copyable `_template/` skeleton: an additive `spec.adoc` (extends, never replaces, the core spec) + schema-conformant `entities/` (`attribute`, `effect`, `ability`, `tag_registry`), plus a `genres/README.md` authoring/convention guide and pack index.
- `scripts/validate_schema_examples.py` now scans `genres/` alongside `schemas/examples/` (per-file logic factored into `validate_example_file`).
- `preview-docs.yml` / `publish-docs.yml`: resolve `%%UGAS_VERSION%%` under `genres/`, build each `genres/<genre>/spec.adoc` to its own page, and (publish) copy `genres/` into the versioned docs dir.
- Adds a changeset (`ugas: minor`).

## Test plan

- [x] `python scripts/validate_schema_examples.py` passes — 8 snippets (4 core + 4 template entities)
- [x] `python scripts/compare_schema_definitions.py` passes
- [x] Negative test: an invalid entity under `genres/` fails validation (confirms new scan root)
- [x] `asciidoctor genres/_template/spec.adoc` builds clean HTML
- [x] CI: confirm `preview-docs` builds `dist/genres/_template/index.html` and `validate-schema-examples` is green on this PR

Part of #28. Follow-up skill tracked in #29.
