### PR TITLE
docs: add genre taxonomy reference (genres/taxonomy.adoc)

### DIFF
--- a/.changeset/genre-taxonomy.md
+++ b/.changeset/genre-taxonomy.md
@@ -1,0 +1,5 @@
+---
+'ugas': patch
+---
+
+[Added] Genre taxonomy reference (`genres/taxonomy.adoc`): a non-normative, published map of video game genres/subgenres that scopes the genre-pack work and positions the ten prioritized packs within the broader space (#28). The docs workflows now build it to `genres/taxonomy.html`.

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -71,6 +71,18 @@ jobs:
               -o "dist/genres/${genre}/index.html"
           done
 
+      - name: Build genre taxonomy with AsciiDoctor
+        run: |
+          if [ -f genres/taxonomy.adoc ]; then
+            mkdir -p dist/genres
+            asciidoctor \
+              -a revnumber="${{ steps.ver.outputs.version }}" \
+              -a ugas-version="${{ steps.ver.outputs.version }}" \
+              -a stem=latexmath \
+              genres/taxonomy.adoc \
+              -o dist/genres/taxonomy.html
+          fi
+
       - name: Generate LLM files
         run: |
           bash scripts/generate-llm-files.sh . dist "${{ steps.ver.outputs.version }}"

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -83,6 +83,17 @@ jobs:
               -o "source/genres/${genre}/index.html"
           done
 
+      - name: Build genre taxonomy with AsciiDoctor
+        run: |
+          if [ -f source/genres/taxonomy.adoc ]; then
+            asciidoctor \
+              -a revnumber="${{ steps.version.outputs.version }}" \
+              -a ugas-version="v${{ steps.version.outputs.version }}" \
+              -a stem=latexmath \
+              source/genres/taxonomy.adoc \
+              -o source/genres/taxonomy.html
+          fi
+
       - name: Generate LLM files
         run: |
           bash source/scripts/generate-llm-files.sh source source "v${{ steps.version.outputs.version }}"

--- a/genres/README.md
+++ b/genres/README.md
@@ -8,6 +8,9 @@ two **additive** artifacts per genre:
    Attributes, Tags, Abilities, and Effects; and
 2. a **template**: ready-to-use, schema-conformant entity files.
 
+See the [genre taxonomy](taxonomy.adoc) for the full map of genres/subgenres and how the
+prioritized packs are positioned within the broader space.
+
 ## Layout contract
 
 Each pack is one self-contained directory under `genres/`, named in kebab-case:

--- a/genres/taxonomy.adoc
+++ b/genres/taxonomy.adoc
@@ -77,6 +77,19 @@ Combines action mechanics with exploration, puzzle-solving, and progression.
 * Metroidvania
 * Open-world action-adventure
 
+[[family-combat]]
+=== Combat
+
+Direct, skill-based confrontation between characters — the dueling/fighting core that the
+*Combat* pack targets. Closely related to the fighting and beat-'em-up subgenres under
+<<family-action>>, but treated as its own pack because its mechanics (movesets, blocking,
+combos, hit trades) differ markedly from projectile-centric shooters.
+
+* Fighting (1v1, arena)
+* Beat 'em up / brawler
+* Hack-and-slash
+* Sports-based fighting
+
 [[family-adventure]]
 === Adventure
 
@@ -233,16 +246,3 @@ first packs.
 combined player-reach and revenue ranking. Simulation remains a first-class family (see
 <<family-simulation>>) and a candidate for a later pack.
 ====
-
-[[family-combat]]
-=== Combat
-
-Direct, skill-based confrontation between characters — the dueling/fighting core that the
-*Combat* pack targets. Closely related to the fighting and beat-'em-up subgenres under
-<<family-action>>, but treated as its own pack because its mechanics (movesets, blocking,
-combos, hit trades) differ markedly from projectile-centric shooters.
-
-* Fighting (1v1, arena)
-* Beat 'em up / brawler
-* Hack-and-slash
-* Sports-based fighting

--- a/genres/taxonomy.adoc
+++ b/genres/taxonomy.adoc
@@ -1,0 +1,248 @@
+= UGAS Video Game Genre Taxonomy
+Mickael Bonfill <jbltx>
+:revnumber: 1.0.0-draft.1
+:ugas-version: v1.0.0-draft.1
+:doctype: book
+:toc: left
+:toc-title: Table of Contents
+:toclevels: 4
+:stem: latexmath
+:source-highlighter: highlight.js
+:icons: font
+:sectanchors:
+:sectlinks:
+:docinfo: shared
+
+[[overview]]
+== Overview
+
+This document is a *reference taxonomy* of video game genres and subgenres. It exists to
+**scope and categorize** the genre-pack work tracked in
+https://github.com/jbltx/ugas/issues/28[issue #28], and to position the ten prioritized
+genres within the broader space of games.
+
+[IMPORTANT]
+====
+This taxonomy is *non-normative*. Unlike a genre `spec.adoc`, it neither extends nor
+constrains the link:../SPEC.adoc[core UGAS specification]. It is a map, not a contract: it
+informs which genre packs we build and how they relate, but it defines no Attributes, Tags,
+Abilities, or Effects. For the genre-pack conventions and authoring rules, see the
+link:README.md[genre packs guide].
+====
+
+[[classification]]
+== How genres are classified
+
+Genres here are organized primarily by **gameplay mechanics** — what the player *does* —
+rather than by setting, theme, art style, or narrative. A medieval-fantasy game and a
+sci-fi game can share the same genre if they share the same core loop.
+
+Two consequences worth keeping in mind:
+
+* *Genres overlap.* Real games routinely blend families (e.g. an action-RPG, a
+  survival-crafting shooter). A title can legitimately sit under more than one family.
+* *Some labels are modifiers, not families.* Properties like _open-world_, _massively
+  multiplayer_, _roguelike_, and _horror_ compose *across* families rather than being
+  families of their own. They are listed separately under <<modifiers>>.
+
+[[families]]
+== Genre families
+
+[[family-action]]
+=== Action
+
+Reflex- and timing-driven gameplay; the core challenge is execution in real time.
+
+* Platformer (2D, 3D, puzzle-platformer)
+* Shooter (emphasized as its own UGAS pack — see <<prioritization>>)
+** First-person shooter (FPS)
+** Third-person shooter (TPS)
+** Hero shooter
+** Light-gun shooter
+** Shoot 'em up (shmup)
+** Battle royale
+* Fighting / Combat (see <<family-combat>>)
+* Beat 'em up
+* Hack-and-slash
+* Stealth
+* Rhythm / music
+* Survival-action
+
+[[family-action-adventure]]
+=== Action-Adventure
+
+Combines action mechanics with exploration, puzzle-solving, and progression.
+
+* Survival horror
+* Metroidvania
+* Open-world action-adventure
+
+[[family-adventure]]
+=== Adventure
+
+Narrative, exploration, and puzzle-solving with little or no reflex-based action.
+
+* Text adventure / interactive fiction
+* Graphic / point-and-click adventure
+* Visual novel
+* Interactive movie
+* Walking simulator / real-time 3D adventure
+
+[[family-rpg]]
+=== Role-Playing (RPG)
+
+Character progression, stats, inventory, and player-driven builds at the core.
+
+* Action RPG (ARPG)
+* Computer / Western RPG (CRPG)
+* Japanese RPG (JRPG)
+* Massively multiplayer online RPG (MMORPG)
+* Roguelike / Roguelite
+* Tactical RPG (TRPG / SRPG)
+* Sandbox / open-world RPG
+* First-person party-based RPG
+* Monster-taming
+
+[[family-simulation]]
+=== Simulation
+
+Models a system or activity with relative fidelity; the goal is to manage or operate it.
+
+* Construction & management (city builder, tycoon, god game)
+* Life simulation
+* Vehicle / flight / space simulation
+* Farming simulation
+
+[[family-strategy]]
+=== Strategy
+
+Planning, resource management, and tactical or operational decision-making.
+
+* 4X (eXplore, eXpand, eXploit, eXterminate)
+* Real-time strategy (RTS)
+* Real-time tactics (RTT)
+* Turn-based strategy (TBS)
+* Turn-based tactics (TBT)
+* Wargame / grand strategy
+* Tower defense
+* Multiplayer online battle arena (MOBA)
+* Auto battler
+* Artillery
+
+[[family-sports]]
+=== Sports
+
+Simulates or abstracts real or fictional sports.
+
+* Traditional sports simulation
+* Arcade sports
+* Sports management
+* Sports-based fighting
+
+[[family-racing]]
+=== Racing
+
+Vehicle competition against time or opponents.
+
+* Simulation (sim) racing
+* Arcade racing
+* Kart racing
+* Combat racing
+
+[[family-puzzle]]
+=== Puzzle
+
+Logic, pattern, and problem-solving challenges.
+
+* Tile-matching
+* Physics
+* Hidden object
+* Programming
+* Puzzle-platformer
+* Logic / traditional puzzle
+* Word / trivia
+
+[[family-survival-crafting]]
+=== Survival & Crafting
+
+Resource gathering, crafting, and base-building under persistent threat or scarcity.
+(Overlaps heavily with <<family-action>> and <<family-simulation>>.)
+
+* Survival
+* Crafting / base-building
+* Sandbox survival
+
+[[family-casual-party]]
+=== Casual & Party
+
+Low-barrier, short-session, or multiplayer-social play.
+
+* Casual
+* Hypercasual
+* Idle / incremental (clicker)
+* Party
+
+[[family-other]]
+=== Other notable genres
+
+* Horror (as a standalone, beyond survival horror)
+* Board / card / casino
+* Gacha
+* Digital collectible card game (CCG)
+* Educational / serious / exergame
+
+[[modifiers]]
+== Cross-cutting modifiers
+
+These labels describe *how* a game is played or framed and combine with the families above
+rather than replacing them.
+
+* *Sandbox / open-world* — non-linear, player-directed exploration of a large space.
+* *Massively multiplayer online (MMO)* — large shared persistent worlds.
+* *Roguelike elements* — procedural generation and permadeath layered onto another genre.
+* *Horror* — a thematic framing that can modify action, adventure, or survival games.
+
+[[prioritization]]
+== UGAS pack prioritization
+
+For the initial genre packs, https://github.com/jbltx/ugas/issues/28[issue #28] prioritizes
+the ten genres below. Selection blends **player reach** (casual ~63%, action & shooter ~39%,
+racing ~37%) with **revenue / market share** (Newzoo, Statista, GAMIVO, 2025–2026). The core
+spec already ships four case studies — platformer, racing, ARPG, and puzzle — which seed the
+first packs.
+
+[cols="1,3,4", options="header"]
+|===
+| # | Genre | Maps to / rationale
+
+| 1 | Action / Action-Adventure | <<family-action>>, <<family-action-adventure>> — the broadest reach and the engine for most real-time gameplay.
+| 2 | Shooter (FPS / TPS) | <<family-action>> (shooter subgenres) — top PC/console revenue category.
+| 3 | Role-Playing (RPG) | <<family-rpg>> — deep progression systems; seeded by the ARPG case study.
+| 4 | Survival / Crafting | <<family-survival-crafting>> — high-engagement, fast-growing category.
+| 5 | Casual | <<family-casual-party>> — largest player base by reach (~63%).
+| 6 | Racing | <<family-racing>> — broad reach (~37%); seeded by the racing case study.
+| 7 | Combat | <<family-combat>> — fighting/dueling mechanics distinct from shooters.
+| 8 | Strategy (RTS / 4X / Tower Defense) | <<family-strategy>> — planning- and resource-driven play.
+| 9 | Sports | <<family-sports>> — consistently strong commercial performers.
+| 10 | Puzzle | <<family-puzzle>> — wide casual reach; seeded by the puzzle case study.
+|===
+
+[NOTE]
+====
+*Combat* replaced *Simulation* in the top ten relative to an earlier draft, reflecting the
+combined player-reach and revenue ranking. Simulation remains a first-class family (see
+<<family-simulation>>) and a candidate for a later pack.
+====
+
+[[family-combat]]
+=== Combat
+
+Direct, skill-based confrontation between characters — the dueling/fighting core that the
+*Combat* pack targets. Closely related to the fighting and beat-'em-up subgenres under
+<<family-action>>, but treated as its own pack because its mechanics (movesets, blocking,
+combos, hit trades) differ markedly from projectile-centric shooters.
+
+* Fighting (1v1, arena)
+* Beat 'em up / brawler
+* Hack-and-slash
+* Sports-based fighting


### PR DESCRIPTION
## Summary

First deliverable of #28 — the **genre taxonomy** that scopes the genre-pack work.

- Adds `genres/taxonomy.adoc`: a *non-normative*, published AsciiDoc map of video game genres/subgenres (12 families + subgenres, cross-cutting modifiers, and a prioritization table mapping the top-10 packs to families with rationale). Header mirrors `_template/spec.adoc`.
- Wires a "Build genre taxonomy" step into `preview-docs.yml` (→ `dist/genres/taxonomy.html`) and `publish-docs.yml` (→ `source/genres/taxonomy.html`). The existing `genres/*/spec.adoc` loop doesn't match a top-level file, so each workflow gets a dedicated step; publish copies it via the existing `cp -r source/genres`.
- Links the taxonomy from `genres/README.md`.
- Changeset: `'ugas': patch`.

## Test plan

- [x] `asciidoctor --failure-level=WARN -a stem=latexmath genres/taxonomy.adoc` builds clean (no warnings, no dead xrefs)
- [x] `python scripts/validate_schema_examples.py` still passes 8 snippets (the `.adoc` is ignored by validation)
- [x] CI: `preview-docs` produces `dist/genres/taxonomy.html` and the Cloudflare preview serves `…/genres/taxonomy.html`; `validate-schema-examples` green