### PR TITLE
feat: add RPG genre pack (genres/rpg)

### DIFF
--- a/.changeset/genre-pack-rpg.md
+++ b/.changeset/genre-pack-rpg.md
@@ -1,0 +1,5 @@
+---
+'ugas': minor
+---
+
+[Added] RPG genre pack (`genres/rpg/`): an additive Role-Playing specification plus a schema-conformant template — `RPGCoreAttributes`, an RPG tag taxonomy, damage-bucket effects (MainStat / DamageBonuses channels), basic-attack and Whirlwind abilities, and a worked Diablo-style hero controller. Seeds the ARPG case study (§15.3) as a ready-to-extend pack (#34).

--- a/genres/README.md
+++ b/genres/README.md
@@ -57,3 +57,4 @@ assistant skill) can load a pack's `entities/` directly as a starting point and 
 | Pack | Status | Spec |
 |------|--------|------|
 | `_template` | Skeleton (reference only) | [`_template/spec.adoc`](_template/spec.adoc) |
+| `rpg` | Role-Playing (RPG) — seeded by the ARPG case study | [`rpg/spec.adoc`](rpg/spec.adoc) |

--- a/genres/rpg/README.md
+++ b/genres/rpg/README.md
@@ -1,0 +1,35 @@
+# UGAS Genre Pack: Role-Playing (RPG)
+
+> Action-RPG (Diablo-style) characters: primary stats, items, abilities, and a
+> multiplicative damage-bucket pipeline.
+
+This pack is the copy-and-extend companion to the **ARPG case study** in the core spec
+(Section 15.3). It ships the matching Attributes, Tags, Abilities, and Effects as
+schema-conformant entities, plus a worked hero example.
+
+## What's in this pack
+
+| File | Purpose |
+|------|---------|
+| `spec.adoc` | Additional RPG specification — extends, never replaces, the core spec |
+| `entities/attribute_set.yaml` | `RPGCoreAttributes`: primary stats, vitals, derived combat stats, progression |
+| `entities/tag_registry.yaml` | RPG tags: damage types, ability types, combat status, items, classes |
+| `entities/effect_mainstat_strength.yaml` | `+1%` WeaponDamage per Strength (`MainStat` channel) |
+| `entities/effect_weapon_firesword.yaml` | Fire Sword equip effect: `+20%` WeaponDamage (`DamageBonuses` channel) |
+| `entities/effect_basic_attack_damage.yaml` | Instant damage equal to the source's WeaponDamage |
+| `entities/effect_regeneration.yaml` | Timed + periodic health regeneration buff |
+| `entities/ability_basic_attack.yaml` | `GA_BasicAttack`: single-target weapon strike |
+| `entities/ability_whirlwind.yaml` | `GA_Whirlwind`: signature melee AoE |
+| `entities/gameplay_controller.yaml` | Worked example: a level-5 Barbarian showing damage-bucket aggregation |
+
+## How to use
+
+1. Read `spec.adoc` for the genre-specific design (especially the damage buckets).
+2. Copy the entity files in `entities/` into your project and adapt them.
+3. They validate against the core `schemas/*.yaml`, so AI agents (e.g. the
+   `ugas-schema-author` skill) can load and extend them directly.
+4. Run `python scripts/validate_schema_examples.py` after changes.
+
+## Published spec
+
+<!-- Link to the built HTML once published, e.g. v<version>/genres/rpg/index.html -->

--- a/genres/rpg/entities/ability_basic_attack.yaml
+++ b/genres/rpg/entities/ability_basic_attack.yaml
@@ -1,0 +1,26 @@
+# Default single-target weapon strike. Free (no cost), short montage, applies weapon damage.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
+Name: GA_BasicAttack
+Tags:
+  AbilityTags:
+    - Ability.Type.Melee
+    - DamageType.Physical
+  ActivationBlockedTags:
+    - State.Dead
+    - State.Debuff.Stunned
+Tasks:
+  - Type: PlayMontage
+    Params:
+      MontageToPlay: Anim_BasicAttack
+      PlayRate: 1.0
+  - Type: WaitGameplayEvent
+    Params:
+      EventTag: Event.Montage.HitWindow
+  - Type: ApplyEffectToTarget
+    Params:
+      EffectClass: GE_BasicAttackDamage
+Metadata:
+  DisplayName: Basic Attack
+  Description: Strike a single target for weapon damage
+  Icon: ui/icons/basic_attack.png

--- a/genres/rpg/entities/ability_whirlwind.yaml
+++ b/genres/rpg/entities/ability_whirlwind.yaml
@@ -1,0 +1,35 @@
+# Signature melee AoE: spins, striking every enemy in radius with the basic-attack damage effect.
+# Models the GA_Whirlwind tag-query example from the core spec (section 15.3).
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
+Name: GA_Whirlwind
+Tags:
+  AbilityTags:
+    - Ability.Type.Melee
+    - DamageType.Physical
+  ActivationRequiredTags:
+    - State.Combat
+  ActivationBlockedTags:
+    - State.Dead
+    - State.Debuff.Stunned
+  ActivationOwnedTags:
+    - State.Combat
+Cost: GE_WhirlwindCost
+Cooldown: GE_WhirlwindCooldown
+Tasks:
+  - Type: PlayMontage
+    Params:
+      MontageToPlay: Anim_Whirlwind
+      PlayRate: 1.0
+  - Type: WaitGameplayEvent
+    Params:
+      EventTag: Event.Montage.HitWindow
+  - Type: ApplyEffectToActorsInRadius
+    Params:
+      Radius: 500.0
+      EffectClass: GE_BasicAttackDamage
+      IgnoreTargetsWithTag: Immunity.Physical
+Metadata:
+  DisplayName: Whirlwind
+  Description: Spin in place, striking all nearby enemies for weapon damage
+  Icon: ui/icons/whirlwind.png

--- a/genres/rpg/entities/attribute_set.yaml
+++ b/genres/rpg/entities/attribute_set.yaml
@@ -1,0 +1,124 @@
+# RPG core attribute set: primary stats, derived combat stats, vitals, and progression.
+# Extends the core spec's attribute model (no core attribute is redefined here).
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/attribute_set.json
+Name: RPGCoreAttributes
+Attributes:
+  # --- Primary attributes (player-allocated, drive everything else) ---
+  - Name: Strength
+    DefaultBaseValue: 10.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Strength
+      Description: Increases physical weapon damage via the MainStat channel
+      UICategory: Primary
+  - Name: Dexterity
+    DefaultBaseValue: 10.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Dexterity
+      Description: Increases attack speed and critical hit chance
+      UICategory: Primary
+  - Name: Intelligence
+    DefaultBaseValue: 10.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Intelligence
+      Description: Increases spell damage and maximum mana
+      UICategory: Primary
+  - Name: Vitality
+    DefaultBaseValue: 10.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Vitality
+      Description: Increases maximum health
+      UICategory: Primary
+
+  # --- Vitals (resources, clamped to their derived maxima) ---
+  - Name: MaxHealth
+    DefaultBaseValue: 100.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Maximum Health
+      UICategory: Vitals
+  - Name: Health
+    DefaultBaseValue: 100.0
+    Category: Resource
+    Clamping:
+      Min: 0
+      Max: MaxHealth
+    ReplicationMode: All
+    Metadata:
+      DisplayName: Health
+      Description: Current life; reaching 0 kills the character
+      UICategory: Vitals
+  - Name: MaxMana
+    DefaultBaseValue: 50.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Maximum Mana
+      UICategory: Vitals
+  - Name: Mana
+    DefaultBaseValue: 50.0
+    Category: Resource
+    Clamping:
+      Min: 0
+      Max: MaxMana
+    ReplicationMode: All
+    Metadata:
+      DisplayName: Mana
+      Description: Resource spent to activate abilities
+      UICategory: Vitals
+
+  # --- Derived combat statistics ---
+  - Name: WeaponDamage
+    DefaultBaseValue: 10.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Weapon Damage
+      Description: Aggregated outgoing damage; target of the damage-bucket channels (see spec section 4)
+      UICategory: Combat
+  - Name: Armor
+    DefaultBaseValue: 0.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Armor
+      Description: Flat physical damage reduction
+      UICategory: Combat
+  - Name: CritChance
+    DefaultBaseValue: 0.05
+    Category: Statistic
+    Clamping:
+      Min: 0
+      Max: 1
+    Metadata:
+      DisplayName: Critical Hit Chance
+      Description: Probability (0..1) that an attack critically strikes
+      UICategory: Combat
+  - Name: CritDamage
+    DefaultBaseValue: 1.5
+    Category: Statistic
+    Metadata:
+      DisplayName: Critical Hit Damage
+      Description: Multiplier applied on a critical strike
+      UICategory: Combat
+
+  # --- Progression ---
+  - Name: Level
+    DefaultBaseValue: 1.0
+    Category: Meta
+    Metadata:
+      DisplayName: Character Level
+      UICategory: Progression
+  - Name: Experience
+    DefaultBaseValue: 0.0
+    Category: Resource
+    Clamping:
+      Min: 0
+    Metadata:
+      DisplayName: Experience
+      Description: Accumulates toward the next level
+      UICategory: Progression
+Metadata:
+  DisplayName: RPG Core Attributes
+  Description: Primary stats, vitals, derived combat stats, and progression for an action-RPG character

--- a/genres/rpg/entities/effect_basic_attack_damage.yaml
+++ b/genres/rpg/entities/effect_basic_attack_damage.yaml
@@ -1,0 +1,16 @@
+# Instant damage dealt by a weapon strike: subtracts the source's fully-aggregated
+# WeaponDamage (after all damage-bucket channels resolve) from the target's Health.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_BasicAttackDamage
+DurationPolicy: Instant
+Modifiers:
+  - Attribute: Health
+    Operation: Add
+    Magnitude:
+      Type: AttributeBased
+      BackingAttribute: WeaponDamage
+      Source: Source
+      Coefficient: -1.0
+GameplayCues:
+  - GameplayCue.Character.Damage

--- a/genres/rpg/entities/effect_mainstat_strength.yaml
+++ b/genres/rpg/entities/effect_mainstat_strength.yaml
@@ -1,0 +1,15 @@
+# MainStat scaling: each point of Strength adds +1% WeaponDamage in the "MainStat" channel.
+# Mirrors the ARPG damage-bucket design in the core spec (section 15.3).
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_MainStat_Strength
+DurationPolicy: Infinite
+Modifiers:
+  - Attribute: WeaponDamage
+    Operation: Multiply
+    Magnitude:
+      Type: AttributeBased
+      BackingAttribute: Strength
+      Source: Source
+      Coefficient: 0.01
+    Channel: MainStat

--- a/genres/rpg/entities/effect_regeneration.yaml
+++ b/genres/rpg/entities/effect_regeneration.yaml
@@ -1,0 +1,20 @@
+# Timed health regeneration buff: restores 5 Health every second for 5 seconds.
+# Demonstrates HasDuration + periodic execution.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_Regeneration
+DurationPolicy: HasDuration
+Duration:
+  Type: ScalableFloat
+  Value: 5.0
+Period:
+  Period: 1.0
+  ExecuteOnApplication: false
+Modifiers:
+  - Attribute: Health
+    Operation: Add
+    Magnitude:
+      Type: ScalableFloat
+      Value: 5.0
+GrantedTags:
+  - State.Buff.Regenerating

--- a/genres/rpg/entities/effect_weapon_firesword.yaml
+++ b/genres/rpg/entities/effect_weapon_firesword.yaml
@@ -1,0 +1,17 @@
+# Equippable item effect: a Fire Sword that grants +20% damage in the "DamageBonuses" channel.
+# Infinite duration while equipped; grants item/element tags consumed by other systems.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_Weapon_FireSword
+DurationPolicy: Infinite
+Modifiers:
+  - Attribute: WeaponDamage
+    Operation: Multiply
+    Magnitude:
+      Type: ScalableFloat
+      Value: 0.20
+    Channel: DamageBonuses
+GrantedTags:
+  - Item.Equipped.Weapon
+  - Item.Type.Sword
+  - DamageType.Fire

--- a/genres/rpg/entities/gameplay_controller.yaml
+++ b/genres/rpg/entities/gameplay_controller.yaml
@@ -1,0 +1,55 @@
+# Worked example: a Diablo-style Barbarian hero, mid-build.
+# WeaponDamage shows the damage-bucket result of the two active effects below:
+#   base 10  x MainStat(1 + 0.01*50 = 1.50)  x DamageBonuses(1 + 0.20 = 1.20)  = 18.0
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_controller.json
+OwnerActor:
+  ActorID: Hero_Barbarian_01
+  ActorType: PlayerCharacter
+AttributeSets:
+  - Name: RPGCoreAttributes
+    Attributes:
+      - Name: Strength
+        BaseValue: 50.0
+        CurrentValue: 50.0
+      - Name: Vitality
+        BaseValue: 20.0
+        CurrentValue: 20.0
+      - Name: MaxHealth
+        BaseValue: 200.0
+        CurrentValue: 200.0
+      - Name: Health
+        BaseValue: 200.0
+        CurrentValue: 200.0
+      - Name: WeaponDamage
+        BaseValue: 10.0
+        CurrentValue: 18.0
+      - Name: Level
+        BaseValue: 5.0
+        CurrentValue: 5.0
+GrantedAbilities:
+  - AbilityClass: GA_BasicAttack
+    Level: 1
+    InputID: BasicAttack
+  - AbilityClass: GA_Whirlwind
+    Level: 5
+    InputID: Ability1
+ActiveEffects:
+  - Handle: eff-mainstat-strength
+    EffectClass: GE_MainStat_Strength
+    Duration: -1
+  - Handle: eff-weapon-firesword
+    EffectClass: GE_Weapon_FireSword
+    Duration: -1
+OwnedTags:
+  - State.Alive
+  - State.Combat
+  - Class.Barbarian
+  - Item.Equipped.Weapon
+  - Item.Type.Sword
+ReplicationMode: Mixed
+bIsActive: true
+Metadata:
+  DisplayName: Barbarian (Level 5)
+  Description: Worked-example hero showing damage-bucket aggregation on WeaponDamage
+  DebugCategory: rpg-pack-example

--- a/genres/rpg/entities/tag_registry.yaml
+++ b/genres/rpg/entities/tag_registry.yaml
@@ -1,0 +1,71 @@
+# RPG genre tag taxonomy. ADDITIVE: this registry introduces genre-specific tags only.
+# It does not redefine core State.* / Ability.* tags — those are referenced, not declared here.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_tag.json
+Tags:
+  # --- Damage types (used by abilities, immunities, and conditional effects) ---
+  - Tag: DamageType.Physical
+    Description: Physical (weapon) damage
+    AllowMultiple: false
+  - Tag: DamageType.Fire
+    Description: Fire elemental damage
+    AllowMultiple: false
+  - Tag: DamageType.Cold
+    Description: Cold elemental damage
+    AllowMultiple: false
+  - Tag: DamageType.Lightning
+    Description: Lightning elemental damage
+    AllowMultiple: false
+  - Tag: DamageType.Poison
+    Description: Poison damage, typically applied over time
+    AllowMultiple: false
+
+  # --- Ability classification ---
+  - Tag: Ability.Type.Melee
+    Description: Close-range physical ability
+    AllowMultiple: false
+  - Tag: Ability.Type.Ranged
+    Description: Projectile or distance physical ability
+    AllowMultiple: false
+  - Tag: Ability.Type.Spell
+    Description: Magic ability that consumes mana
+    AllowMultiple: false
+
+  # --- Combat status (drive conditional damage buckets and immunities) ---
+  - Tag: Status.Vulnerable
+    Description: Target takes increased damage while present
+    AllowMultiple: false
+  - Tag: Status.FightingElite
+    Description: Source is engaged with an elite enemy
+    AllowMultiple: false
+  - Tag: Immunity.Physical
+    Description: Target ignores incoming physical damage
+    AllowMultiple: false
+  - Tag: Immunity.Fire
+    Description: Target ignores incoming fire damage
+    AllowMultiple: false
+
+  # --- Items (granted by equip effects) ---
+  - Tag: Item.Equipped.Weapon
+    Description: A weapon is equipped in the main hand
+    AllowMultiple: false
+  - Tag: Item.Equipped.Armor
+    Description: A body armor piece is equipped
+    AllowMultiple: false
+  - Tag: Item.Type.Sword
+    Description: Item is a sword
+    AllowMultiple: false
+  - Tag: Item.Rarity.Legendary
+    Description: Item is of legendary rarity
+    AllowMultiple: false
+
+  # --- Character classes ---
+  - Tag: Class.Barbarian
+    Description: Strength-based melee class
+    AllowMultiple: false
+  - Tag: Class.Sorcerer
+    Description: Intelligence-based caster class
+    AllowMultiple: false
+  - Tag: Class.Rogue
+    Description: Dexterity-based skirmisher class
+    AllowMultiple: false

--- a/genres/rpg/spec.adoc
+++ b/genres/rpg/spec.adoc
@@ -1,0 +1,129 @@
+= UGAS Genre Pack: Role-Playing (RPG)
+Mickael Bonfill <jbltx>
+:revnumber: 1.0.0-draft.1
+:ugas-version: v1.0.0-draft.1
+:doctype: book
+:toc: left
+:toc-title: Table of Contents
+:toclevels: 4
+:stem: latexmath
+:source-highlighter: highlight.js
+:icons: font
+:sectanchors:
+:sectlinks:
+:docinfo: shared
+
+[[overview]]
+== Overview
+
+This genre pack targets *action role-playing games* (ARPGs) in the Diablo / Path of Exile
+mould: a character defined by primary attributes, equippable items that roll stat modifiers,
+signature abilities, and — above all — a *multiplicative damage pipeline* that has to stay
+sane as item counts grow.
+
+It is the practical, copy-and-extend companion to the *ARPG (Diablo-style)* case study in
+link:../../SPEC.adoc[the core specification] (Section 15.3). Where the case study explains the
+_Damage Bucket_ architecture, this pack ships the matching schema-conformant Attributes, Tags,
+Abilities, and Effects in `entities/`, plus a worked hero in `entities/gameplay_controller.yaml`.
+
+[[relationship-to-core-spec]]
+== Relationship to the core specification
+
+This document is *additive*. It defines genre-specific Attributes, Tags, Abilities, and
+Effects on top of the core Universal Gameplay Ability System specification.
+
+* It MUST NOT redefine, override, or contradict any concept in the core spec.
+* All entities in `entities/` validate against the same `schemas/*.json` as the core.
+* It *reuses* core state tags (`State.Alive`, `State.Combat`, `State.Dead`,
+  `State.Debuff.Stunned`, `State.Buff.Regenerating`) by reference — it never re-declares them.
+* The damage-bucket stacking it relies on is the core modifier `Channel` mechanism
+  (link:../../SPEC.adoc[core spec] §5.3 and §15.3), not a new construct.
+
+[[genre-attributes]]
+== Genre Attributes
+
+Defined in `entities/attribute_set.yaml` as the `RPGCoreAttributes` set.
+
+[cols="1,1,3",options="header"]
+|===
+| Attribute | Category | Role
+
+| `Strength`, `Dexterity`, `Intelligence`, `Vitality` | Statistic | Primary, player-allocated stats that feed everything else.
+| `MaxHealth` / `Health` | Statistic / Resource | `Health` is clamped to `[0, MaxHealth]`; reaching 0 kills the character.
+| `MaxMana` / `Mana` | Statistic / Resource | `Mana` is clamped to `[0, MaxMana]` and spent by ability costs.
+| `WeaponDamage` | Statistic | The aggregated outgoing-damage stat targeted by the damage buckets.
+| `Armor`, `CritChance`, `CritDamage` | Statistic | Derived combat stats. `CritChance` is clamped to `[0, 1]`.
+| `Level`, `Experience` | Meta / Resource | Progression. `Experience` accumulates toward the next `Level`.
+|===
+
+[[genre-damage-buckets]]
+== Damage buckets (the core RPG mechanic)
+
+ARPG power scaling is multiplicative across *named channels* and additive *within* a channel.
+This pack uses three canonical channels, all aggregating onto `WeaponDamage`:
+
+[cols="1,3,2",options="header"]
+|===
+| Channel | What goes in it | Stacking
+
+| `MainStat` | Primary-stat scaling (e.g. Strength → +damage) | Additive within
+| `DamageBonuses` | Conditional / item damage bonuses (fire, vs. elites, while healthy …) | Additive within
+| `LegendaryPowers` | Item-set / legendary multipliers | Additive within, multiplied across the others
+|===
+
+Because channels are part of the core modifier pipeline, the stacking is expressed
+*declaratively* in Effect YAML — no custom calculation code is needed for it.
+
+.Worked example (`entities/gameplay_controller.yaml`)
+With `Strength = 50` and the Fire Sword equipped:
+
+* `MainStat` factor: latexmath:[1 + (0.01 \times 50) = 1.50]
+* `DamageBonuses` factor: latexmath:[1 + 0.20 = 1.20]
+* Final `WeaponDamage`: latexmath:[10 \times 1.50 \times 1.20 = 18.0]
+
+This is exactly the `CurrentValue` recorded for `WeaponDamage` on the example hero.
+
+[[genre-tags]]
+== Genre Tags
+
+Defined in `entities/tag_registry.yaml` (additive only):
+
+* *Damage types* — `DamageType.Physical|Fire|Cold|Lightning|Poison`.
+* *Ability types* — `Ability.Type.Melee|Ranged|Spell`.
+* *Combat status* — `Status.Vulnerable`, `Status.FightingElite`; immunities
+  `Immunity.Physical`, `Immunity.Fire`.
+* *Items* — `Item.Equipped.*`, `Item.Type.*`, `Item.Rarity.Legendary`.
+* *Classes* — `Class.Barbarian|Sorcerer|Rogue`.
+
+[[genre-abilities]]
+== Genre Abilities
+
+* `entities/ability_basic_attack.yaml` — `GA_BasicAttack`: free single-target weapon strike;
+  plays a montage and applies `GE_BasicAttackDamage` on the hit window.
+* `entities/ability_whirlwind.yaml` — `GA_Whirlwind`: signature melee AoE. Tagged
+  `Ability.Type.Melee` + `DamageType.Physical`, blocked while `State.Dead` /
+  `State.Debuff.Stunned`, applies the damage effect to every target in radius while skipping
+  `Immunity.Physical` targets. Models the `GA_Whirlwind` tag-query example from §15.3.
+
+[[genre-effects]]
+== Genre Effects
+
+* `entities/effect_mainstat_strength.yaml` — `GE_MainStat_Strength`: infinite; `+1%`
+  `WeaponDamage` per point of `Strength` in the `MainStat` channel (`AttributeBased`).
+* `entities/effect_weapon_firesword.yaml` — `GE_Weapon_FireSword`: infinite equip effect;
+  `+20%` `WeaponDamage` in the `DamageBonuses` channel and grants item/element tags.
+* `entities/effect_basic_attack_damage.yaml` — `GE_BasicAttackDamage`: instant; subtracts the
+  source's fully-aggregated `WeaponDamage` from the target's `Health`.
+* `entities/effect_regeneration.yaml` — `GE_Regeneration`: `HasDuration` + `Period`; restores
+  `5` `Health` per second for `5` seconds.
+
+[[using-this-pack]]
+== Using this pack
+
+. Copy `genres/rpg/` into your project (or load `entities/` directly via the
+  `ugas-schema-author` skill).
+. Keep, rename, or extend the `RPGCoreAttributes` set; add classes/skills as new
+  Abilities and Effects.
+. Author new damage modifiers by choosing the right `Channel` — additive bonuses go in
+  `DamageBonuses`, set/legendary multipliers in `LegendaryPowers`.
+. Validate with `python scripts/validate_schema_examples.py` before committing.


### PR DESCRIPTION
## Summary

Authors the **RPG genre pack** (#34) — the first of the ten packs from #28 — seeded by the ARPG (Diablo-style) case study in `SPEC.adoc` §15.3. Additive only: it extends the core spec, never overrides it.

Ships under `genres/rpg/`:
- **`spec.adoc`** — additive RPG spec: primary/derived attributes, the damage-bucket pipeline (MainStat / DamageBonuses / LegendaryPowers channels), RPG tag taxonomy, abilities, effects, and a worked hero example with the bucket math.
- **`entities/`** (all `$schema`-tagged, schema-conformant):
  - `attribute_set.yaml` — `RPGCoreAttributes` (Strength/Dex/Int/Vit, vitals, WeaponDamage, crit, Level/XP)
  - `tag_registry.yaml` — damage types, ability types, combat status, items, classes (additive; reuses core `State.*` by reference)
  - `effect_mainstat_strength.yaml`, `effect_weapon_firesword.yaml` — damage-bucket channel modifiers
  - `effect_basic_attack_damage.yaml`, `effect_regeneration.yaml`
  - `ability_basic_attack.yaml`, `ability_whirlwind.yaml`
  - `gameplay_controller.yaml` — worked Diablo-style Barbarian; `WeaponDamage` CurrentValue (18.0) demonstrates `10 × 1.50 × 1.20`
- `README.md`, pack-index row in `genres/README.md`, and a changeset (`'ugas': minor`).

## Acceptance criteria (#34)

- [x] Additive spec with no contradictions/overrides of `SPEC.adoc`
- [x] Template entity set validating against `schemas/*.yaml`
- [x] Worked example (the hero controller ties to the §15.3 damage-bucket math)
- [x] Consumable by the `ugas-schema-author` skill (plain `entities/*.yaml`)
- [x] Changeset included

## Test plan

- [x] `python scripts/validate_schema_examples.py` → passes, 17 snippets (was 8)
- [x] `asciidoctor --failure-level=WARN genres/rpg/spec.adoc` → builds clean
- [x] CI: `validate-schema-examples` green; `preview-docs` builds `dist/genres/rpg/index.html` and the Cloudflare preview serves it