### PR TITLE
feat: add Racing genre pack (genres/racing) (#37)

### DIFF
--- a/.changeset/genre-pack-racing.md
+++ b/.changeset/genre-pack-racing.md
@@ -1,0 +1,5 @@
+---
+'ugas': minor
+---
+
+[Added] Racing genre pack (`genres/racing/`): an additive Forza-style racing specification plus a schema-conformant template — `VehiclePerformanceSet`, a racing tag taxonomy, a two-channel traction pipeline (Surface / Upgrades) with surface and tuning effects, nitro-boost and drift abilities, an `ExecutionCalculation` traction recompute, and a worked tuned-Sport-car controller. Seeds the Racing case study (§15.2) as a ready-to-extend pack (#37).

--- a/genres/README.md
+++ b/genres/README.md
@@ -58,3 +58,4 @@ assistant skill) can load a pack's `entities/` directly as a starting point and 
 |------|--------|------|
 | `_template` | Skeleton (reference only) | [`_template/spec.adoc`](_template/spec.adoc) |
 | `rpg` | Role-Playing (RPG) — seeded by the ARPG case study | [`rpg/spec.adoc`](rpg/spec.adoc) |
+| `racing` | Racing (Forza-style) — seeded by the Racing case study | [`racing/spec.adoc`](racing/spec.adoc) |

--- a/genres/racing/README.md
+++ b/genres/racing/README.md
@@ -1,0 +1,37 @@
+# UGAS Genre Pack: Racing
+
+> Forza-style driving: vehicle performance attributes, track surfaces, tuning parts,
+> driver abilities, and a traction pipeline that aggregates grip from every source.
+
+This pack is the copy-and-extend companion to the **Racing case study** in the core spec
+(Section 15.2). It ships the matching Attributes, Tags, Abilities, and Effects as
+schema-conformant entities, plus a worked vehicle example.
+
+## What's in this pack
+
+| File | Purpose |
+|------|---------|
+| `spec.adoc` | Additional Racing specification — extends, never replaces, the core spec |
+| `entities/attribute_set.yaml` | `VehiclePerformanceSet`: drivetrain, aero, tires, boost resource, telemetry |
+| `entities/tag_registry.yaml` | Racing tags: surfaces, vehicle classes/states, ability types, race phases |
+| `entities/effect_tuning_sport.yaml` | Infinite tuning upgrade: drivetrain + `+10%` grip (`Upgrades` channel) |
+| `entities/effect_biome_mud.yaml` | Mud surface: `-60%` grip (`Surface` channel) and lower top speed |
+| `entities/effect_biome_asphalt.yaml` | Asphalt surface: overrides `Surface`-channel grip to the `1.0` baseline |
+| `entities/effect_nitro_boost.yaml` | Timed nitro burst applied by `GA_NitroBoost` |
+| `entities/effect_drift_charge.yaml` | Timed + periodic boost refill granted while drifting |
+| `entities/effect_traction_update.yaml` | Instant `ExecutionCalculation` recomputing `AvailableTraction` |
+| `entities/ability_nitro_boost.yaml` | `GA_NitroBoost`: spend boost for a burst of performance |
+| `entities/ability_drift.yaml` | `GA_Drift`: hold to slide, trading grip for boost charge |
+| `entities/gameplay_controller.yaml` | Worked example: a tuned Sport car on mud showing traction aggregation |
+
+## How to use
+
+1. Read `spec.adoc` for the genre-specific design (especially the traction pipeline).
+2. Copy the entity files in `entities/` into your project and adapt them.
+3. They validate against the core `schemas/*.yaml`, so AI agents (e.g. the
+   `ugas-schema-author` skill) can load and extend them directly.
+4. Run `python scripts/validate_schema_examples.py` after changes.
+
+## Published spec
+
+<!-- Link to the built HTML once published, e.g. v<version>/genres/racing/index.html -->

--- a/genres/racing/entities/ability_drift.yaml
+++ b/genres/racing/entities/ability_drift.yaml
@@ -1,0 +1,23 @@
+# Drift ability: hold to slide. Grants Vehicle.State.Drifting and refills boost via GE_DriftCharge,
+# trading cornering grip for nitro charge. Ends when the input is released.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
+Name: GA_Drift
+Tags:
+  AbilityTags:
+    - Ability.Type.Handling
+  ActivationRequiredTags:
+    - Vehicle
+  ActivationBlockedTags:
+    - Vehicle.State.SpunOut
+  ActivationOwnedTags:
+    - Vehicle.State.Drifting
+Tasks:
+  - Type: ApplyEffectToOwner
+    Params:
+      EffectClass: GE_DriftCharge
+  - Type: WaitInputRelease
+Metadata:
+  DisplayName: Drift
+  Description: Hold to slide through corners, converting grip into boost charge
+  Icon: ui/icons/drift.png

--- a/genres/racing/entities/ability_nitro_boost.yaml
+++ b/genres/racing/entities/ability_nitro_boost.yaml
@@ -1,0 +1,23 @@
+# Nitro boost ability: spend the boost resource for a short burst of power.
+# Costs boost (GE_NitroCost) and goes on cooldown (GE_NitroCooldown); applies GE_NitroBoost to self.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
+Name: GA_NitroBoost
+Tags:
+  AbilityTags:
+    - Ability.Type.Boost
+  ActivationRequiredTags:
+    - Vehicle
+    - Race.Phase.Racing
+  ActivationBlockedTags:
+    - Vehicle.State.SpunOut
+Cost: GE_NitroCost
+Cooldown: GE_NitroCooldown
+Tasks:
+  - Type: ApplyEffectToOwner
+    Params:
+      EffectClass: GE_NitroBoost
+Metadata:
+  DisplayName: Nitro Boost
+  Description: Burn boost charge for a burst of torque and top speed
+  Icon: ui/icons/nitro.png

--- a/genres/racing/entities/attribute_set.yaml
+++ b/genres/racing/entities/attribute_set.yaml
@@ -1,0 +1,91 @@
+# Vehicle performance attribute set: drivetrain, aero, tires, and the boost resource.
+# Extends the core spec's attribute model (no core attribute is redefined here).
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/attribute_set.json
+Name: VehiclePerformanceSet
+Attributes:
+  # --- Drivetrain (the power the engine puts to the wheels) ---
+  - Name: EngineTorque
+    DefaultBaseValue: 400.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Engine Torque
+      Description: Base drive torque in Nm; raised by tuning upgrades
+      UICategory: Drivetrain
+  - Name: MaxSpeed
+    DefaultBaseValue: 250.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Top Speed
+      Description: Top speed in km/h; lowered by heavy/low-grip surfaces, raised by boost
+      UICategory: Drivetrain
+
+  # --- Aerodynamics & tires (feed the traction pipeline) ---
+  - Name: AeroDownforce
+    DefaultBaseValue: 100.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Aero Downforce
+      Description: Downforce coefficient; scales effective traction with speed (see spec section 4)
+      UICategory: Chassis
+  - Name: TireGripMultiplier
+    DefaultBaseValue: 1.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Tire Grip
+      Description: Aggregated grip; target of the Surface and Upgrades channels (see spec section 4)
+      UICategory: Tires
+  - Name: TireTemperature
+    DefaultBaseValue: 80.0
+    Category: Statistic
+    Clamping:
+      Min: 20.0
+      Max: 150.0
+    Metadata:
+      DisplayName: Tire Temperature
+      Description: Tire core temperature in degrees C; grip peaks in the 80-100 window
+      UICategory: Tires
+
+  # --- Boost resource (spent by the nitro ability, refilled by drifting) ---
+  - Name: MaxBoost
+    DefaultBaseValue: 100.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Maximum Boost
+      UICategory: Boost
+  - Name: Boost
+    DefaultBaseValue: 100.0
+    Category: Resource
+    Clamping:
+      Min: 0
+      Max: MaxBoost
+    ReplicationMode: All
+    Metadata:
+      DisplayName: Boost
+      Description: Nitro charge spent to activate GA_NitroBoost
+      UICategory: Boost
+
+  # --- Runtime physics state (driven each frame by the simulation / traction calc) ---
+  - Name: EngineRPM
+    DefaultBaseValue: 0.0
+    Category: Meta
+    Metadata:
+      DisplayName: Engine RPM
+      UICategory: Telemetry
+  - Name: CurrentSpeed
+    DefaultBaseValue: 0.0
+    Category: Meta
+    Metadata:
+      DisplayName: Current Speed
+      Description: Live ground speed in km/h read by the traction calculation
+      UICategory: Telemetry
+  - Name: AvailableTraction
+    DefaultBaseValue: 1.0
+    Category: Meta
+    Metadata:
+      DisplayName: Available Traction
+      Description: Output of ExecCalc_VehicleTraction; couples grip, downforce, and tire temperature
+      UICategory: Telemetry
+Metadata:
+  DisplayName: Vehicle Performance Set
+  Description: Drivetrain, aerodynamics, tires, boost resource, and runtime telemetry for a racing vehicle

--- a/genres/racing/entities/effect_biome_asphalt.yaml
+++ b/genres/racing/entities/effect_biome_asphalt.yaml
@@ -1,0 +1,17 @@
+# Surface area effect: dry asphalt. Overrides the Surface-channel grip to the clean 1.0 baseline,
+# clearing any prior off-track penalty. Infinite while the vehicle is on the surface.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_Biome_Asphalt
+DurationPolicy: Infinite
+ApplicationRequiredTags:
+  - Vehicle
+Modifiers:
+  - Attribute: TireGripMultiplier
+    Operation: Override
+    Magnitude:
+      Type: ScalableFloat
+      Value: 1.0
+    Channel: Surface
+GrantedTags:
+  - Surface.Asphalt

--- a/genres/racing/entities/effect_biome_mud.yaml
+++ b/genres/racing/entities/effect_biome_mud.yaml
@@ -1,0 +1,22 @@
+# Surface area effect: driving onto mud. Cuts grip in the "Surface" channel and lowers top speed.
+# Infinite while the vehicle is on the surface; applied/removed by the track's area volumes.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_Biome_Mud
+DurationPolicy: Infinite
+ApplicationRequiredTags:
+  - Vehicle
+Modifiers:
+  - Attribute: TireGripMultiplier
+    Operation: Multiply
+    Magnitude:
+      Type: ScalableFloat
+      Value: -0.6
+    Channel: Surface
+  - Attribute: MaxSpeed
+    Operation: Add
+    Magnitude:
+      Type: ScalableFloat
+      Value: -30.0
+GrantedTags:
+  - Surface.Mud

--- a/genres/racing/entities/effect_drift_charge.yaml
+++ b/genres/racing/entities/effect_drift_charge.yaml
@@ -1,0 +1,20 @@
+# Drift charge: while sliding, periodically refill the boost resource.
+# HasDuration + Period demonstrates timed, repeating execution (refreshed each tick GA_Drift holds).
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_DriftCharge
+DurationPolicy: HasDuration
+Duration:
+  Type: ScalableFloat
+  Value: 5.0
+Period:
+  Period: 0.5
+  ExecuteOnApplication: false
+Modifiers:
+  - Attribute: Boost
+    Operation: Add
+    Magnitude:
+      Type: ScalableFloat
+      Value: 10.0
+GrantedTags:
+  - Vehicle.State.Drifting

--- a/genres/racing/entities/effect_nitro_boost.yaml
+++ b/genres/racing/entities/effect_nitro_boost.yaml
@@ -1,0 +1,24 @@
+# Nitro boost: a short burst of extra power applied by GA_NitroBoost.
+# HasDuration so it self-expires; grants Vehicle.State.Boosting for cues and ability gating.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_NitroBoost
+DurationPolicy: HasDuration
+Duration:
+  Type: ScalableFloat
+  Value: 3.0
+Modifiers:
+  - Attribute: EngineTorque
+    Operation: Add
+    Magnitude:
+      Type: ScalableFloat
+      Value: 120.0
+  - Attribute: MaxSpeed
+    Operation: Add
+    Magnitude:
+      Type: ScalableFloat
+      Value: 40.0
+GrantedTags:
+  - Vehicle.State.Boosting
+GameplayCues:
+  - GameplayCue.Vehicle.NitroFlame

--- a/genres/racing/entities/effect_traction_update.yaml
+++ b/genres/racing/entities/effect_traction_update.yaml
@@ -1,0 +1,9 @@
+# Traction recompute: couples the declarative grip stat to the non-linear physics.
+# An ExecutionCalculation reads grip, downforce, speed, and tire temperature and writes
+# AvailableTraction. Instant; the simulation re-applies it each physics step.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_Traction_Update
+DurationPolicy: Instant
+Executions:
+  - CalculatorClass: ExecCalc_VehicleTraction

--- a/genres/racing/entities/effect_tuning_sport.yaml
+++ b/genres/racing/entities/effect_tuning_sport.yaml
@@ -1,0 +1,27 @@
+# Sport tuning package: a permanent performance upgrade fitted to the vehicle.
+# Raises drivetrain output (flat) and grip in the "Upgrades" channel of the traction pipeline.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_Tuning_Sport
+DurationPolicy: Infinite
+ApplicationRequiredTags:
+  - Vehicle
+Modifiers:
+  - Attribute: EngineTorque
+    Operation: Add
+    Magnitude:
+      Type: ScalableFloat
+      Value: 80.0
+  - Attribute: MaxSpeed
+    Operation: Add
+    Magnitude:
+      Type: ScalableFloat
+      Value: 20.0
+  - Attribute: TireGripMultiplier
+    Operation: Multiply
+    Magnitude:
+      Type: ScalableFloat
+      Value: 0.10
+    Channel: Upgrades
+GrantedTags:
+  - Vehicle.Tuned

--- a/genres/racing/entities/gameplay_controller.yaml
+++ b/genres/racing/entities/gameplay_controller.yaml
@@ -1,0 +1,60 @@
+# Worked example: a Sport-class car mid-race, on mud, with the sport tuning package fitted.
+# CurrentValue columns show the result of the two infinite effects below:
+#   TireGripMultiplier: base 1.0 x Surface(1 - 0.6 = 0.40) x Upgrades(1 + 0.10 = 1.10) = 0.44
+#   MaxSpeed:           base 250 + Tuning(+20) + Mud(-30)                               = 240.0
+#   EngineTorque:       base 400 + Tuning(+80)                                          = 480.0
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_controller.json
+OwnerActor:
+  ActorID: Vehicle_SportCar_01
+  ActorType: PlayerVehicle
+AttributeSets:
+  - Name: VehiclePerformanceSet
+    Attributes:
+      - Name: EngineTorque
+        BaseValue: 400.0
+        CurrentValue: 480.0
+      - Name: MaxSpeed
+        BaseValue: 250.0
+        CurrentValue: 240.0
+      - Name: TireGripMultiplier
+        BaseValue: 1.0
+        CurrentValue: 0.44
+      - Name: AeroDownforce
+        BaseValue: 100.0
+        CurrentValue: 100.0
+      - Name: TireTemperature
+        BaseValue: 80.0
+        CurrentValue: 95.0
+      - Name: MaxBoost
+        BaseValue: 100.0
+        CurrentValue: 100.0
+      - Name: Boost
+        BaseValue: 100.0
+        CurrentValue: 60.0
+GrantedAbilities:
+  - AbilityClass: GA_NitroBoost
+    Level: 1
+    InputID: Boost
+  - AbilityClass: GA_Drift
+    Level: 1
+    InputID: Drift
+ActiveEffects:
+  - Handle: eff-tuning-sport
+    EffectClass: GE_Tuning_Sport
+    Duration: -1
+  - Handle: eff-biome-mud
+    EffectClass: GE_Biome_Mud
+    Duration: -1
+OwnedTags:
+  - Vehicle
+  - Vehicle.Class.Sport
+  - Vehicle.Tuned
+  - Surface.Mud
+  - Race.Phase.Racing
+ReplicationMode: Mixed
+bIsActive: true
+Metadata:
+  DisplayName: Sport Car (tuned, on mud)
+  Description: Worked-example vehicle showing traction-pipeline aggregation on TireGripMultiplier
+  DebugCategory: racing-pack-example

--- a/genres/racing/entities/tag_registry.yaml
+++ b/genres/racing/entities/tag_registry.yaml
@@ -1,0 +1,71 @@
+# Racing genre tag taxonomy. ADDITIVE: this registry introduces genre-specific tags only.
+# It does not redefine core State.* / Ability.* tags - those are referenced, not declared here.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_tag.json
+Tags:
+  # --- Track surfaces (granted by area/biome effects; drive the grip pipeline) ---
+  - Tag: Surface.Asphalt
+    Description: Dry sealed track; full baseline grip
+    AllowMultiple: false
+  - Tag: Surface.Mud
+    Description: Soft off-track surface; heavy grip and speed penalty
+    AllowMultiple: false
+  - Tag: Surface.Gravel
+    Description: Loose run-off surface; moderate grip penalty
+    AllowMultiple: false
+  - Tag: Surface.Ice
+    Description: Frozen surface; severe grip penalty
+    AllowMultiple: false
+  - Tag: Surface.Wet
+    Description: Rain-soaked surface; reduced grip and aquaplaning risk
+    AllowMultiple: false
+
+  # --- Vehicle classification (target gating + class-specific tuning) ---
+  - Tag: Vehicle
+    Description: Entity is a controllable vehicle; required by surface/area effects
+    AllowMultiple: false
+  - Tag: Vehicle.Class.Sport
+    Description: Balanced road/sports car
+    AllowMultiple: false
+  - Tag: Vehicle.Class.Kart
+    Description: Lightweight kart; high agility, low top speed
+    AllowMultiple: false
+  - Tag: Vehicle.Class.Formula
+    Description: Open-wheel racer; high downforce and top speed
+    AllowMultiple: false
+  - Tag: Vehicle.Tuned
+    Description: A performance tuning upgrade is installed
+    AllowMultiple: false
+
+  # --- Vehicle dynamic states (granted by abilities and timed effects) ---
+  - Tag: Vehicle.State.Boosting
+    Description: Nitro boost is currently active
+    AllowMultiple: false
+  - Tag: Vehicle.State.Drifting
+    Description: Vehicle is in a controlled slide, building boost charge
+    AllowMultiple: false
+  - Tag: Vehicle.State.SpunOut
+    Description: Vehicle has lost control; blocks driver abilities
+    AllowMultiple: false
+
+  # --- Ability classification ---
+  - Tag: Ability.Type.Boost
+    Description: Consumes the boost resource for a burst of performance
+    AllowMultiple: false
+  - Tag: Ability.Type.Handling
+    Description: Driving technique that alters grip or builds resource
+    AllowMultiple: false
+
+  # --- Race progression / status ---
+  - Tag: Race.Phase.Countdown
+    Description: Pre-start countdown; driver inputs locked
+    AllowMultiple: false
+  - Tag: Race.Phase.Racing
+    Description: Race is live and timed
+    AllowMultiple: false
+  - Tag: Race.Phase.Finished
+    Description: Vehicle has crossed the finish line
+    AllowMultiple: false
+  - Tag: Race.Status.FinalLap
+    Description: The leader has started the last lap
+    AllowMultiple: false

--- a/genres/racing/spec.adoc
+++ b/genres/racing/spec.adoc
@@ -1,0 +1,154 @@
+= UGAS Genre Pack: Racing
+Mickael Bonfill <jbltx>
+:revnumber: 1.0.0-draft.1
+:ugas-version: v1.0.0-draft.1
+:doctype: book
+:toc: left
+:toc-title: Table of Contents
+:toclevels: 4
+:stem: latexmath
+:source-highlighter: highlight.js
+:icons: font
+:sectanchors:
+:sectlinks:
+:docinfo: shared
+
+[[overview]]
+== Overview
+
+This genre pack targets *driving and racing games* in the Forza / Gran Turismo / arcade-kart
+mould: a vehicle defined by drivetrain and chassis attributes, track surfaces and tuning parts
+that modify performance, signature driver abilities (nitro, drift), and — at its core — a
+*traction pipeline* that has to stay coherent as surfaces, upgrades, and physics all push on grip
+at once.
+
+It is the practical, copy-and-extend companion to the *Racing (Forza-style)* case study in
+link:../../SPEC.adoc[the core specification] (Section 15.2). Where the case study sketches the
+vehicle attribute set, biome surface effects, and the traction `ExecutionCalculation`, this pack
+ships the matching schema-conformant Attributes, Tags, Abilities, and Effects in `entities/`, plus
+a worked vehicle in `entities/gameplay_controller.yaml`.
+
+[[relationship-to-core-spec]]
+== Relationship to the core specification
+
+This document is *additive*. It defines genre-specific Attributes, Tags, Abilities, and
+Effects on top of the core Universal Gameplay Ability System specification.
+
+* It MUST NOT redefine, override, or contradict any concept in the core spec.
+* All entities in `entities/` validate against the same `schemas/*.json` as the core.
+* It *reuses* core state tags (`State.Alive`, `State.Combat`, …) by reference where relevant —
+  it never re-declares them.
+* The grip stacking it relies on is the core modifier `Channel` mechanism
+  (link:../../SPEC.adoc[core spec] §5.3 and §15.2), and the non-linear physics coupling is a core
+  `ExecutionCalculation` — neither is a new construct.
+
+[[genre-attributes]]
+== Genre Attributes
+
+Defined in `entities/attribute_set.yaml` as the `VehiclePerformanceSet` set.
+
+[cols="1,1,3",options="header"]
+|===
+| Attribute | Category | Role
+
+| `EngineTorque` | Statistic | Drive torque (Nm); raised by tuning upgrades.
+| `MaxSpeed` | Statistic | Top speed (km/h); lowered by low-grip surfaces, raised by boost.
+| `AeroDownforce` | Statistic | Downforce coefficient; scales effective traction with speed.
+| `TireGripMultiplier` | Statistic | The aggregated grip stat targeted by the traction channels.
+| `TireTemperature` | Statistic | Tire core temperature (°C), clamped to `[20, 150]`; grip peaks in the 80–100 window.
+| `MaxBoost` / `Boost` | Statistic / Resource | `Boost` is clamped to `[0, MaxBoost]`; spent by the nitro ability and refilled by drifting.
+| `EngineRPM`, `CurrentSpeed`, `AvailableTraction` | Meta | Runtime telemetry written each frame by the physics simulation and the traction calc.
+|===
+
+[[genre-traction-pipeline]]
+== The traction pipeline (the core racing mechanic)
+
+Grip in a racing game is pushed on from several directions at once — the surface under the tires,
+the parts bolted to the car, downforce that grows with speed, and tire temperature. UGAS expresses
+this in two complementary layers, both landing on `TireGripMultiplier` / `AvailableTraction`.
+
+=== Declarative grip channels
+
+Surface and upgrade modifiers stack through *named channels*: additive *within* a channel,
+multiplicative *across* channels — exactly the damage-bucket mechanism from §15.3, reused for grip.
+
+[cols="1,3,2",options="header"]
+|===
+| Channel | What goes in it | Stacking
+
+| `Surface` | The current track surface (asphalt, mud, gravel, ice, wet) | Additive within
+| `Upgrades` | Tuning parts and tire compounds | Additive within, multiplied across the others
+|===
+
+Because channels are part of the core modifier pipeline, surface and tuning effects stack
+*declaratively* in Effect YAML — no custom calculation code is needed for them.
+
+.Worked example (`entities/gameplay_controller.yaml`)
+A Sport-class car with the sport tuning package fitted, driving on mud:
+
+* `Surface` factor (mud, latexmath:[-0.6]): latexmath:[1 + (-0.6) = 0.40]
+* `Upgrades` factor (tuning, latexmath:[+0.10]): latexmath:[1 + 0.10 = 1.10]
+* Final `TireGripMultiplier`: latexmath:[1.0 \times 0.40 \times 1.10 = 0.44]
+
+The same two effects add flat drivetrain changes: `EngineTorque` latexmath:[400 + 80 = 480] and
+`MaxSpeed` latexmath:[250 + 20 - 30 = 240]. These are exactly the `CurrentValue` entries recorded
+for the example vehicle.
+
+=== Physics coupling via ExecutionCalculation
+
+Downforce scaling (latexmath:[\propto \text{speed}^2]) and the tire-temperature window are
+*non-linear*, so they live in an `ExecutionCalculation` rather than a channel. `GE_Traction_Update`
+(`entities/effect_traction_update.yaml`) invokes `ExecCalc_VehicleTraction`, which reads the
+aggregated `TireGripMultiplier`, `AeroDownforce`, `TireTemperature`, and `CurrentSpeed` and writes
+`AvailableTraction`. The simulation re-applies this instant effect each physics step. See §15.2 for
+the reference calculation body.
+
+[[genre-tags]]
+== Genre Tags
+
+Defined in `entities/tag_registry.yaml` (additive only):
+
+* *Surfaces* — `Surface.Asphalt|Mud|Gravel|Ice|Wet`.
+* *Vehicle classification* — the base `Vehicle` tag (required by surface effects),
+  `Vehicle.Class.Sport|Kart|Formula`, and `Vehicle.Tuned`.
+* *Vehicle states* — `Vehicle.State.Boosting|Drifting|SpunOut`.
+* *Ability types* — `Ability.Type.Boost|Handling`.
+* *Race progression* — `Race.Phase.Countdown|Racing|Finished`, `Race.Status.FinalLap`.
+
+[[genre-abilities]]
+== Genre Abilities
+
+* `entities/ability_nitro_boost.yaml` — `GA_NitroBoost`: spends the `Boost` resource
+  (`Cost: GE_NitroCost`) on a cooldown (`GE_NitroCooldown`) and applies `GE_NitroBoost` to the
+  vehicle. Blocked while `Vehicle.State.SpunOut`; requires `Race.Phase.Racing`.
+* `entities/ability_drift.yaml` — `GA_Drift`: hold-to-slide handling technique. Grants
+  `Vehicle.State.Drifting` while active and applies the periodic `GE_DriftCharge`, trading
+  cornering grip for boost charge. Ends on input release (`WaitInputRelease`).
+
+[[genre-effects]]
+== Genre Effects
+
+* `entities/effect_tuning_sport.yaml` — `GE_Tuning_Sport`: infinite upgrade; flat
+  `+EngineTorque` / `+MaxSpeed` and `+10%` grip in the `Upgrades` channel; grants `Vehicle.Tuned`.
+* `entities/effect_biome_mud.yaml` — `GE_Biome_Mud`: infinite surface; `-60%` grip in the
+  `Surface` channel and `-30` `MaxSpeed`; grants `Surface.Mud`. Requires the `Vehicle` tag.
+* `entities/effect_biome_asphalt.yaml` — `GE_Biome_Asphalt`: infinite surface; `Override`s the
+  `Surface`-channel grip back to the `1.0` baseline; grants `Surface.Asphalt`.
+* `entities/effect_nitro_boost.yaml` — `GE_NitroBoost`: `HasDuration` burst; flat
+  `+EngineTorque` / `+MaxSpeed`; grants `Vehicle.State.Boosting`.
+* `entities/effect_drift_charge.yaml` — `GE_DriftCharge`: `HasDuration` + `Period`; restores
+  `Boost` every half-second; grants `Vehicle.State.Drifting`.
+* `entities/effect_traction_update.yaml` — `GE_Traction_Update`: instant; runs the
+  `ExecCalc_VehicleTraction` `ExecutionCalculation` to recompute `AvailableTraction`.
+
+[[using-this-pack]]
+== Using this pack
+
+. Copy `genres/racing/` into your project (or load `entities/` directly via the
+  `ugas-schema-author` skill).
+. Keep, rename, or extend the `VehiclePerformanceSet`; add vehicle classes/parts as new
+  Effects, and driver techniques as new Abilities.
+. Author new grip modifiers by choosing the right `Channel` — surface conditions go in
+  `Surface`, parts and compounds in `Upgrades`; reserve `ExecutionCalculation`s for non-linear
+  physics coupling.
+. Validate with `python scripts/validate_schema_examples.py` before committing.


### PR DESCRIPTION
## Summary
Adds the **Racing (Forza-style)** genre pack under `genres/racing/`, seeded by the Racing case study (§15.2) and mirroring the structure of the merged RPG pack (#42). Part of #28; closes #37.

- **`VehiclePerformanceSet`** — drivetrain, aero, tires, a clamped boost resource, and runtime telemetry attributes.
- **Traction pipeline** — a two-channel grip aggregation (`Surface` × `Upgrades`, reusing the core modifier `Channel` mechanism from §5.3/§15.3) plus a non-linear physics layer via an `ExecutionCalculation` (`GE_Traction_Update` → `ExecCalc_VehicleTraction` → `AvailableTraction`).
- **Effects** — sport tuning, the two case-study biome surfaces (mud / asphalt), a timed nitro burst, and a periodic drift-charge refill.
- **Abilities** — `GA_NitroBoost` (spends the boost resource, on cooldown) and `GA_Drift` (hold-to-slide, trades grip for boost charge).
- **Worked controller** — a tuned Sport car on mud: `TireGripMultiplier = 1.0 × 0.40 × 1.10 = 0.44`, `MaxSpeed = 250 + 20 − 30 = 240`, `EngineTorque = 400 + 80 = 480`.
- Pack `README.md`, `spec.adoc`, a `genres/README.md` index row, and a changeset (`'ugas': minor`).

## Test plan
- [x] `python scripts/validate_schema_examples.py` — passes, 28 snippets (+11 racing entities)
- [x] `asciidoctor --failure-level=WARN -a stem=latexmath genres/racing/spec.adoc` — exit 0, no warnings, no dangling xrefs
- [x] CI `validate-schema-examples` green and `preview-docs` builds the pack on the PR