### PR TITLE
feat: add Action/Action-Adventure genre pack (genres/action) (#32)

### DIFF
--- a/.changeset/genre-pack-action.md
+++ b/.changeset/genre-pack-action.md
@@ -1,0 +1,5 @@
+---
+'ugas': minor
+---
+
+[Added] Action / Action-Adventure genre pack (`genres/action/`): an additive platformer specification plus a schema-conformant template — `PlatformerMovementSet`, an action tag taxonomy, a tag-driven movement state machine (grounded / in-air / coyote time) with effect-owned transitions, a variable-height `GA_Jump` and `GA_GroundPound`, power-up effects (super mushroom, invincibility star) using the size/speed channels, and a worked "Super" hero controller. Seeds the Platformer case study (§15.1) as a ready-to-extend pack (#32).

--- a/genres/README.md
+++ b/genres/README.md
@@ -59,3 +59,4 @@ assistant skill) can load a pack's `entities/` directly as a starting point and 
 | `_template` | Skeleton (reference only) | [`_template/spec.adoc`](_template/spec.adoc) |
 | `rpg` | Role-Playing (RPG) — seeded by the ARPG case study | [`rpg/spec.adoc`](rpg/spec.adoc) |
 | `racing` | Racing (Forza-style) — seeded by the Racing case study | [`racing/spec.adoc`](racing/spec.adoc) |
+| `action` | Action / Action-Adventure — seeded by the Platformer case study | [`action/spec.adoc`](action/spec.adoc) |

--- a/genres/action/README.md
+++ b/genres/action/README.md
@@ -1,0 +1,37 @@
+# UGAS Genre Pack: Action / Action-Adventure
+
+> Mario-style platforming: tight movement attributes, a variable-height jump, power-ups,
+> and a tag-driven movement state machine — the core of the wider action-adventure family.
+
+This pack is the copy-and-extend companion to the **Platformer case study** in the core spec
+(Section 15.1). It ships the matching Attributes, Tags, Abilities, and Effects as
+schema-conformant entities, plus a worked hero example.
+
+## What's in this pack
+
+| File | Purpose |
+|------|---------|
+| `spec.adoc` | Additional Action specification — extends, never replaces, the core spec |
+| `entities/attribute_set.yaml` | `PlatformerMovementSet`: jump/movement feel, form, and vitals |
+| `entities/tag_registry.yaml` | Action tags: movement states, power-ups, ability types, hazards |
+| `entities/effect_grounded.yaml` | `GE_Grounded`: physics-owned grounded state |
+| `entities/effect_in_air.yaml` | `GE_InAir`: airborne state granted by `GA_Jump` |
+| `entities/effect_jump_cut.yaml` | `GE_JumpCut`: raises gravity for a variable-height jump |
+| `entities/effect_super_mushroom.yaml` | `GE_SuperMushroom`: doubles size, grants `+1` health |
+| `entities/effect_invincibility_star.yaml` | `GE_InvincibilityStar`: timed immunity + speed boost |
+| `entities/effect_contact_damage.yaml` | `GE_ContactDamage`: `-1` health on contact |
+| `entities/ability_jump.yaml` | `GA_Jump`: signature variable-height jump |
+| `entities/ability_ground_pound.yaml` | `GA_GroundPound`: airborne radius slam |
+| `entities/gameplay_controller.yaml` | Worked example: a "Super" hero showing power-up aggregation |
+
+## How to use
+
+1. Read `spec.adoc` for the genre-specific design (especially the movement state machine).
+2. Copy the entity files in `entities/` into your project and adapt them.
+3. They validate against the core `schemas/*.yaml`, so AI agents (e.g. the
+   `ugas-schema-author` skill) can load and extend them directly.
+4. Run `python scripts/validate_schema_examples.py` after changes.
+
+## Published spec
+
+<!-- Link to the built HTML once published, e.g. v<version>/genres/action/index.html -->

--- a/genres/action/entities/ability_ground_pound.yaml
+++ b/genres/action/entities/ability_ground_pound.yaml
@@ -1,0 +1,25 @@
+# Ground pound: slam down from the air, damaging every enemy in a small radius on impact.
+# Only usable while airborne; reuses GE_ContactDamage and skips Immunity.Contact targets.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
+Name: GA_GroundPound
+Tags:
+  AbilityTags:
+    - Ability.Type.Attack
+  ActivationRequiredTags:
+    - State.InAir
+  ActivationBlockedTags:
+    - State.Grounded
+Tasks:
+  - Type: WaitGameplayEvent
+    Params:
+      EventTag: Event.Landed
+  - Type: ApplyEffectToActorsInRadius
+    Params:
+      Radius: 200.0
+      EffectClass: GE_ContactDamage
+      IgnoreTargetsWithTag: Immunity.Contact
+Metadata:
+  DisplayName: Ground Pound
+  Description: Slam to the ground, damaging nearby enemies on impact
+  Icon: ui/icons/ground_pound.png

--- a/genres/action/entities/ability_jump.yaml
+++ b/genres/action/entities/ability_jump.yaml
@@ -1,0 +1,33 @@
+# Variable-height jump (the signature platformer ability), from the §15.1 case study.
+# Activation gate is State.Grounded OR Status.CoyoteTime - that OR is evaluated in the ability's
+# activation logic, since tag lists are ANDed and cannot express it declaratively.
+# Task order is the happy path: GE_JumpCut is only applied if VerticalVelocity > 0 at release.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
+Name: GA_Jump
+Tags:
+  AbilityTags:
+    - Ability.Type.Movement
+Tasks:
+  - Type: ApplyEffectToOwner
+    Params:
+      EffectClass: GE_InAir
+  - Type: WaitInputRelease
+    Params:
+      InputID: Jump
+  - Type: ApplyEffectToOwner
+    Params:
+      EffectClass: GE_JumpCut
+  - Type: WaitGameplayEvent
+    Params:
+      EventTag: Event.Landed
+  - Type: RemoveEffectFromOwner
+    Params:
+      EffectClass: GE_InAir
+  - Type: RemoveEffectFromOwner
+    Params:
+      EffectClass: GE_JumpCut
+Metadata:
+  DisplayName: Jump
+  Description: Leap upward; hold for a higher jump, release early to cut it short
+  Icon: ui/icons/jump.png

--- a/genres/action/entities/attribute_set.yaml
+++ b/genres/action/entities/attribute_set.yaml
@@ -1,0 +1,104 @@
+# Platformer movement attribute set: jump feel, air control, plus vitals and size for power-ups.
+# Extends the core spec's attribute model (no core attribute is redefined here).
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/attribute_set.json
+Name: PlatformerMovementSet
+Attributes:
+  # --- Jump & movement feel (tuned for "game feel"; read by the movement abilities) ---
+  - Name: GravityScale
+    DefaultBaseValue: 1.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Gravity Scale
+      Description: Multiplier on world gravity; raised by GE_JumpCut for variable-height jumps
+      UICategory: Movement
+  - Name: JumpVelocity
+    DefaultBaseValue: 1200.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Jump Velocity
+      Description: Upward impulse applied by GA_Jump
+      UICategory: Movement
+  - Name: AirControl
+    DefaultBaseValue: 0.65
+    Category: Statistic
+    Clamping:
+      Min: 0.0
+      Max: 1.0
+    Metadata:
+      DisplayName: Air Control
+      Description: Fraction (0..1) of ground control retained while airborne
+      UICategory: Movement
+  - Name: HorizontalSpeed
+    DefaultBaseValue: 600.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Run Speed
+      Description: Ground movement speed; raised while the invincibility star is active
+      UICategory: Movement
+  - Name: CoyoteTimeDuration
+    DefaultBaseValue: 0.15
+    Category: Statistic
+    Metadata:
+      DisplayName: Coyote Time
+      Description: Grace window (s) after leaving a ledge during which a jump still counts
+      UICategory: Movement
+  - Name: JumpBufferDuration
+    DefaultBaseValue: 0.1
+    Category: Statistic
+    Metadata:
+      DisplayName: Jump Buffer
+      Description: Window (s) before landing during which a jump input is queued
+      UICategory: Movement
+  - Name: MaxJumpCount
+    DefaultBaseValue: 1.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Max Jumps
+      Description: Jumps allowed before touching ground; raise to 2 for a double jump
+      UICategory: Movement
+  - Name: VerticalVelocity
+    DefaultBaseValue: 0.0
+    Category: Meta
+    Metadata:
+      DisplayName: Vertical Velocity
+      Description: Live vertical velocity kept in sync by the physics avatar; read by GA_Jump
+      UICategory: Telemetry
+
+  # --- Form & vitals (targeted by power-ups and hazard damage) ---
+  - Name: Scale
+    DefaultBaseValue: 1.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Character Scale
+      Description: Visual/collision size; doubled by the Super power-up via the SizeBonuses channel
+      UICategory: Form
+  - Name: MaxHealth
+    DefaultBaseValue: 3.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Maximum Health
+      UICategory: Vitals
+  - Name: Health
+    DefaultBaseValue: 1.0
+    Category: Resource
+    Clamping:
+      Min: 0
+      Max: MaxHealth
+    ReplicationMode: All
+    Metadata:
+      DisplayName: Health
+      Description: Hit points; reaching 0 costs a life
+      UICategory: Vitals
+  - Name: Lives
+    DefaultBaseValue: 3.0
+    Category: Resource
+    Clamping:
+      Min: 0
+    Metadata:
+      DisplayName: Lives
+      Description: Remaining lives; game over at 0
+      UICategory: Vitals
+Metadata:
+  DisplayName: Platformer Movement Set
+  Description: Jump/movement feel attributes plus form and vitals for an action-platformer character

--- a/genres/action/entities/effect_contact_damage.yaml
+++ b/genres/action/entities/effect_contact_damage.yaml
@@ -1,0 +1,15 @@
+# Contact damage: one hit point removed on touch. Used both ways - by hazards/enemies striking
+# the player, and by GA_GroundPound striking enemies. Targets holding Immunity.Contact are
+# skipped by the applying ability (see GA_GroundPound).
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_ContactDamage
+DurationPolicy: Instant
+Modifiers:
+  - Attribute: Health
+    Operation: Add
+    Magnitude:
+      Type: ScalableFloat
+      Value: -1.0
+GameplayCues:
+  - GameplayCue.Character.Hit

--- a/genres/action/entities/effect_grounded.yaml
+++ b/genres/action/entities/effect_grounded.yaml
@@ -1,0 +1,9 @@
+# Grounded state: granted while the character stands on the ground.
+# Owned by the physics subsystem - it applies this on landing and removes it on takeoff.
+# Tag ownership follows responsibility (§3.1): abilities never mutate State.Grounded directly.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_Grounded
+DurationPolicy: Infinite
+GrantedTags:
+  - State.Grounded

--- a/genres/action/entities/effect_in_air.yaml
+++ b/genres/action/entities/effect_in_air.yaml
@@ -1,0 +1,8 @@
+# Airborne state: granted by GA_Jump on takeoff and removed on landing.
+# Grants State.InAir so other abilities (e.g. GA_GroundPound) can gate on being airborne.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_InAir
+DurationPolicy: Infinite
+GrantedTags:
+  - State.InAir

--- a/genres/action/entities/effect_invincibility_star.yaml
+++ b/genres/action/entities/effect_invincibility_star.yaml
@@ -1,0 +1,22 @@
+# Invincibility star: a timed power-up that ignores contact damage and boosts run speed.
+# HasDuration so it self-expires; grants Immunity.Contact (consumed by hazard/attack effects).
+# Channel SpeedBonuses: factor = 1 + 0.3 = 1.3x HorizontalSpeed while active.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_InvincibilityStar
+DurationPolicy: HasDuration
+Duration:
+  Type: ScalableFloat
+  Value: 10.0
+Modifiers:
+  - Attribute: HorizontalSpeed
+    Operation: Multiply
+    Magnitude:
+      Type: ScalableFloat
+      Value: 0.3
+    Channel: SpeedBonuses
+GrantedTags:
+  - State.PowerUp.Invincible
+  - Immunity.Contact
+GameplayCues:
+  - GameplayCue.PowerUp.Star

--- a/genres/action/entities/effect_jump_cut.yaml
+++ b/genres/action/entities/effect_jump_cut.yaml
@@ -1,0 +1,15 @@
+# Variable-height jump cut: applied when the jump button is released while still rising.
+# Raises gravity (the §15.1 "gravity multiplier for shorter jump") so the character falls
+# sooner. GA_Jump removes it on landing alongside GE_InAir.
+# Channel JumpControl uses the additive-within-channel convention: factor = 1 + 1.5 = 2.5x gravity.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_JumpCut
+DurationPolicy: Infinite
+Modifiers:
+  - Attribute: GravityScale
+    Operation: Multiply
+    Magnitude:
+      Type: ScalableFloat
+      Value: 1.5
+    Channel: JumpControl

--- a/genres/action/entities/effect_super_mushroom.yaml
+++ b/genres/action/entities/effect_super_mushroom.yaml
@@ -1,0 +1,23 @@
+# Super power-up: doubles the character's size and grants one extra hit point.
+# From the §15.1 case study. The Scale modifier sits in the SizeBonuses channel, where the
+# additive-within-channel convention reads Value 1.0 as +100%: factor = 1 + 1.0 = 2.0x size.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_SuperMushroom
+DurationPolicy: Infinite
+GrantedTags:
+  - State.PowerUp.Super
+Modifiers:
+  - Attribute: Scale
+    Operation: Multiply
+    Magnitude:
+      Type: ScalableFloat
+      Value: 1.0
+    Channel: SizeBonuses
+  - Attribute: Health
+    Operation: Add
+    Magnitude:
+      Type: ScalableFloat
+      Value: 1.0
+GameplayCues:
+  - GameplayCue.PowerUp.Super

--- a/genres/action/entities/gameplay_controller.yaml
+++ b/genres/action/entities/gameplay_controller.yaml
@@ -1,0 +1,60 @@
+# Worked example: a "Super" platformer hero standing on the ground after grabbing a mushroom.
+# CurrentValue columns show the result of the active GE_SuperMushroom:
+#   Scale:  base 1.0 x SizeBonuses(1 + 1.0 = 2.0) = 2.0
+#   Health: base 1   + 1 (mushroom)               = 2.0
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_controller.json
+OwnerActor:
+  ActorID: Hero_Platformer_01
+  ActorType: PlayerCharacter
+AttributeSets:
+  - Name: PlatformerMovementSet
+    Attributes:
+      - Name: GravityScale
+        BaseValue: 1.0
+        CurrentValue: 1.0
+      - Name: JumpVelocity
+        BaseValue: 1200.0
+        CurrentValue: 1200.0
+      - Name: AirControl
+        BaseValue: 0.65
+        CurrentValue: 0.65
+      - Name: HorizontalSpeed
+        BaseValue: 600.0
+        CurrentValue: 600.0
+      - Name: Scale
+        BaseValue: 1.0
+        CurrentValue: 2.0
+      - Name: MaxHealth
+        BaseValue: 3.0
+        CurrentValue: 3.0
+      - Name: Health
+        BaseValue: 1.0
+        CurrentValue: 2.0
+      - Name: Lives
+        BaseValue: 3.0
+        CurrentValue: 3.0
+GrantedAbilities:
+  - AbilityClass: GA_Jump
+    Level: 1
+    InputID: Jump
+  - AbilityClass: GA_GroundPound
+    Level: 1
+    InputID: GroundPound
+ActiveEffects:
+  - Handle: eff-grounded
+    EffectClass: GE_Grounded
+    Duration: -1
+  - Handle: eff-super-mushroom
+    EffectClass: GE_SuperMushroom
+    Duration: -1
+OwnedTags:
+  - State.Alive
+  - State.Grounded
+  - State.PowerUp.Super
+ReplicationMode: Mixed
+bIsActive: true
+Metadata:
+  DisplayName: Super Hero (grounded)
+  Description: Worked-example platformer hero showing power-up attribute aggregation on Scale and Health
+  DebugCategory: action-pack-example

--- a/genres/action/entities/tag_registry.yaml
+++ b/genres/action/entities/tag_registry.yaml
@@ -1,0 +1,50 @@
+# Action / platformer genre tag taxonomy. ADDITIVE: introduces genre-specific tags only,
+# including the platformer movement states under the core State.* namespace as used by the
+# §15.1 case study. It does not redefine the core State.Alive / State.Combat / State.Dead
+# lifecycle tags - those are referenced, not declared here.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_tag.json
+Tags:
+  # --- Movement states (granted by Effects; tag ownership follows responsibility, §3.1) ---
+  - Tag: State.Grounded
+    Description: Character is standing on ground; owned by the physics subsystem (GE_Grounded)
+    AllowMultiple: false
+  - Tag: State.InAir
+    Description: Character is airborne; granted by GA_Jump (GE_InAir), removed on landing
+    AllowMultiple: false
+  - Tag: Status.CoyoteTime
+    Description: Brief grace window after leaving a ledge during which a jump still counts
+    AllowMultiple: false
+  - Tag: Status.JumpBuffered
+    Description: A jump input was queued just before landing
+    AllowMultiple: false
+
+  # --- Power-up states (granted by power-up Effects) ---
+  - Tag: State.PowerUp.Super
+    Description: Enlarged "super" form; survives one extra hit
+    AllowMultiple: false
+  - Tag: State.PowerUp.Fire
+    Description: Fire form; enables a ranged attack
+    AllowMultiple: false
+  - Tag: State.PowerUp.Invincible
+    Description: Temporary invincibility (star); ignores contact damage
+    AllowMultiple: false
+
+  # --- Ability classification ---
+  - Tag: Ability.Type.Movement
+    Description: Locomotion ability (jump, dash, climb)
+    AllowMultiple: false
+  - Tag: Ability.Type.Attack
+    Description: Offensive ability (stomp, ground pound, projectile)
+    AllowMultiple: false
+
+  # --- Hazards & combat (the action-adventure surface) ---
+  - Tag: DamageType.Contact
+    Description: Damage from touching an enemy or hazard
+    AllowMultiple: false
+  - Tag: DamageType.Pit
+    Description: Falling out of bounds; typically instant
+    AllowMultiple: false
+  - Tag: Immunity.Contact
+    Description: Ignores incoming contact damage (e.g. while invincible)
+    AllowMultiple: false

--- a/genres/action/spec.adoc
+++ b/genres/action/spec.adoc
@@ -1,0 +1,161 @@
+= UGAS Genre Pack: Action / Action-Adventure
+Mickael Bonfill <jbltx>
+:revnumber: 1.0.0-draft.1
+:ugas-version: v1.0.0-draft.1
+:doctype: book
+:toc: left
+:toc-title: Table of Contents
+:toclevels: 4
+:stem: latexmath
+:source-highlighter: highlight.js
+:icons: font
+:sectanchors:
+:sectlinks:
+:docinfo: shared
+
+[[overview]]
+== Overview
+
+This genre pack targets *action games* in the Mario / Celeste / Hollow Knight mould: a
+character defined by tight movement attributes, a *variable-height jump*, power-ups that change
+form and grant abilities, and a movement *state machine* — grounded, airborne, coyote time —
+that has to stay consistent while abilities, physics, and power-ups all read and write it.
+
+It is the practical, copy-and-extend companion to the *Platformer (Mario-style)* case study in
+link:../../SPEC.adoc[the core specification] (Section 15.1). Where the case study sketches the
+movement attribute set, the variable-height `GA_Jump`, and power-up effects, this pack ships the
+matching schema-conformant Attributes, Tags, Abilities, and Effects in `entities/`, plus a worked
+hero in `entities/gameplay_controller.yaml`.
+
+Platforming is the concrete seed, but the same pieces generalize to the wider *Action /
+Action-Adventure* family — hack-and-slash, stealth, Metroidvania — which layer combat, exploration,
+and progression on top of this movement-and-ability core.
+
+[[relationship-to-core-spec]]
+== Relationship to the core specification
+
+This document is *additive*. It defines genre-specific Attributes, Tags, Abilities, and
+Effects on top of the core Universal Gameplay Ability System specification.
+
+* It MUST NOT redefine, override, or contradict any concept in the core spec.
+* All entities in `entities/` validate against the same `schemas/*.json` as the core.
+* It *reuses* the core lifecycle tags (`State.Alive`, `State.Combat`, `State.Dead`) by reference,
+  and adds the platformer movement states (`State.Grounded`, `State.InAir`, …) introduced by the
+  §15.1 case study.
+* Movement state is mutated *only through Effects* (core spec §3.1) — abilities never write tags
+  directly — and the size/speed power-up stacking is the core modifier `Channel` mechanism
+  (link:../../SPEC.adoc[core spec] §5.3), not a new construct.
+
+[[genre-attributes]]
+== Genre Attributes
+
+Defined in `entities/attribute_set.yaml` as the `PlatformerMovementSet` set.
+
+[cols="1,1,3",options="header"]
+|===
+| Attribute | Category | Role
+
+| `GravityScale` | Statistic | Multiplier on world gravity; raised by `GE_JumpCut` to cut a jump short.
+| `JumpVelocity` | Statistic | Upward impulse applied by `GA_Jump`.
+| `AirControl` | Statistic | Fraction of ground control retained while airborne; clamped to `[0, 1]`.
+| `HorizontalSpeed` | Statistic | Ground run speed; raised while the invincibility star is active.
+| `CoyoteTimeDuration`, `JumpBufferDuration` | Statistic | Forgiveness windows that make the jump feel responsive.
+| `MaxJumpCount` | Statistic | Jumps allowed before landing; raise to `2` for a double jump.
+| `VerticalVelocity` | Meta | Live vertical velocity kept in sync by the physics avatar; read by `GA_Jump`.
+| `Scale` | Statistic | Character size; doubled by the Super power-up.
+| `MaxHealth` / `Health` | Statistic / Resource | `Health` is clamped to `[0, MaxHealth]`; reaching 0 costs a life.
+| `Lives` | Resource | Remaining lives; game over at 0.
+|===
+
+[[genre-movement-state-machine]]
+== The movement state machine (the core action mechanic)
+
+A platformer lives or dies on *game feel*, and in UGAS that feel is a small *tag-driven state
+machine* whose transitions are owned by whichever system is responsible for them.
+
+=== Tag ownership follows responsibility
+
+[cols="1,2,2",options="header"]
+|===
+| State tag | Owner | How it changes
+
+| `State.Grounded` | Physics subsystem | Applied via `GE_Grounded` on landing, removed on takeoff.
+| `State.InAir` | `GA_Jump` | Granted via `GE_InAir` on takeoff, removed on `Event.Landed`.
+| `Status.CoyoteTime` | Physics / movement | A short grace window after leaving a ledge.
+| `Status.JumpBuffered` | Input layer | A jump pressed just before landing is queued.
+|===
+
+No system writes another's tag, and *no system mutates tags directly* — every transition goes
+through an Effect (core spec §3.1). This is why `GA_Jump` does not toggle `State.Grounded`; it only
+grants and later removes its own `GE_InAir`.
+
+=== Variable-height jump
+
+`GA_Jump` (`entities/ability_jump.yaml`) is gated by `State.Grounded` *or* `Status.CoyoteTime`
+(an OR evaluated in activation logic, since tag lists are ANDed). On activation it grants
+`GE_InAir` and applies the `JumpVelocity` impulse, then waits on input release: a short press
+applies `GE_JumpCut`, which raises `GravityScale` so the character falls sooner. On `Event.Landed`
+both effects are removed.
+
+`GE_JumpCut` stacks its gravity multiplier in the `JumpControl` channel, where modifiers are
+additive within the channel: latexmath:[1 + 1.5 = 2.5], i.e. `GravityScale` becomes
+latexmath:[1.0 \times 2.5 = 2.5] while the cut is active.
+
+=== Power-ups change attributes and grant tags
+
+Power-ups are Effects that grant a `State.PowerUp.*` tag and modify attributes. Percentage changes
+use named channels (additive within, multiplicative across), so `Value: 1.0` in the `SizeBonuses`
+channel reads as +100%.
+
+.Worked example (`entities/gameplay_controller.yaml`)
+A hero who has grabbed a Super Mushroom (`GE_SuperMushroom` active):
+
+* `Scale`: base latexmath:[1.0 \times (1 + 1.0) = 2.0] (the `SizeBonuses` channel)
+* `Health`: base latexmath:[1 + 1 = 2] (a flat `Add`)
+
+These are exactly the `CurrentValue` entries recorded for the example hero.
+
+[[genre-tags]]
+== Genre Tags
+
+Defined in `entities/tag_registry.yaml` (additive only):
+
+* *Movement states* — `State.Grounded`, `State.InAir`, `Status.CoyoteTime`, `Status.JumpBuffered`.
+* *Power-up states* — `State.PowerUp.Super|Fire|Invincible`.
+* *Ability types* — `Ability.Type.Movement|Attack`.
+* *Hazards & combat* — `DamageType.Contact|Pit`, `Immunity.Contact`.
+
+[[genre-abilities]]
+== Genre Abilities
+
+* `entities/ability_jump.yaml` — `GA_Jump`: the signature variable-height jump. Grants `GE_InAir`,
+  applies the jump impulse, applies `GE_JumpCut` on early release, and cleans up both on landing.
+* `entities/ability_ground_pound.yaml` — `GA_GroundPound`: an airborne slam. Requires `State.InAir`,
+  blocked while `State.Grounded`, and on `Event.Landed` applies `GE_ContactDamage` to every enemy in
+  radius — skipping `Immunity.Contact` targets. Models the §15.3 radius/tag-query pattern for action.
+
+[[genre-effects]]
+== Genre Effects
+
+* `entities/effect_grounded.yaml` — `GE_Grounded`: infinite; grants `State.Grounded`
+  (applied/removed by the physics subsystem).
+* `entities/effect_in_air.yaml` — `GE_InAir`: infinite; grants `State.InAir` (owned by `GA_Jump`).
+* `entities/effect_jump_cut.yaml` — `GE_JumpCut`: infinite-until-landing; `+150%` `GravityScale`
+  in the `JumpControl` channel for a shorter jump.
+* `entities/effect_super_mushroom.yaml` — `GE_SuperMushroom`: infinite; doubles `Scale`
+  (`SizeBonuses` channel) and grants `+1` `Health`; grants `State.PowerUp.Super`.
+* `entities/effect_invincibility_star.yaml` — `GE_InvincibilityStar`: `HasDuration`; `+30%`
+  `HorizontalSpeed` and grants `State.PowerUp.Invincible` + `Immunity.Contact`.
+* `entities/effect_contact_damage.yaml` — `GE_ContactDamage`: instant; `-1` `Health`. Used by
+  hazards against the player and by `GA_GroundPound` against enemies.
+
+[[using-this-pack]]
+== Using this pack
+
+. Copy `genres/action/` into your project (or load `entities/` directly via the
+  `ugas-schema-author` skill).
+. Keep, rename, or extend the `PlatformerMovementSet`; tune the jump-feel attributes first — they
+  carry most of the game feel.
+. Add new states as `State.*` tags granted by Effects (never mutate tags directly), and new
+  power-ups/attacks as Effects + Abilities.
+. Validate with `python scripts/validate_schema_examples.py` before committing.


### PR DESCRIPTION
## Summary
Adds the **Action / Action-Adventure** genre pack under `genres/action/`, seeded by the Platformer (Mario-style) case study (§15.1) and mirroring the merged RPG (#42) and Racing (#43) packs. Part of #28; closes #32.

- **`PlatformerMovementSet`** — jump/movement feel (gravity, jump velocity, air control, coyote time, jump buffer), `VerticalVelocity` telemetry, plus form (`Scale`) and vitals (`Health`/`Lives`).
- **Movement state machine** — a tag-driven state machine where transitions are *effect-owned* (physics owns `State.Grounded` via `GE_Grounded`; `GA_Jump` owns `State.InAir` via `GE_InAir`), honoring the §3.1 "no direct tag mutation" rule.
- **Abilities** — `GA_Jump` (variable-height: grant `GE_InAir` → wait for release → `GE_JumpCut` → clean up on `Event.Landed`) and `GA_GroundPound` (airborne radius slam reusing `GE_ContactDamage`, skipping `Immunity.Contact`).
- **Power-ups** — `GE_SuperMushroom` (doubles `Scale` via the `SizeBonuses` channel, `+1` health) and `GE_InvincibilityStar` (timed `Immunity.Contact` + `+30%` speed).
- **Worked controller** — a "Super" hero: `Scale = 1.0 × 2.0 = 2.0`, `Health = 1 + 1 = 2`.
- Pack `README.md`, `spec.adoc`, a `genres/README.md` index row, and a changeset (`'ugas': minor`).

## Test plan
- [x] `python scripts/validate_schema_examples.py` — passes, 39 snippets (+11 action entities)
- [x] `asciidoctor --failure-level=WARN -a stem=latexmath genres/action/spec.adoc` — exit 0, no warnings, no dangling xrefs
- [x] CI `validate-schema-examples` green and `preview-docs` builds the pack on the PR