### PR TITLE
docs: surface genre pack templates from published docs root

### DIFF
--- a/.changeset/link-templates-docs.md
+++ b/.changeset/link-templates-docs.md
@@ -1,0 +1,5 @@
+---
+'ugas': patch
+---
+
+[Added] Genre pack discoverability from the published docs root: a rendered genre-packs landing page (`genres/index.adoc` → `genres/index.html`) linked from the docs README version table, a "Genre Packs (templates)" section in `llms.txt`, and the pack template entities appended to `llms-full.txt` (#28).

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -83,6 +83,18 @@ jobs:
               -o dist/genres/taxonomy.html
           fi
 
+      - name: Build genre packs index with AsciiDoctor
+        run: |
+          if [ -f genres/index.adoc ]; then
+            mkdir -p dist/genres
+            asciidoctor \
+              -a revnumber="${{ steps.ver.outputs.version }}" \
+              -a ugas-version="${{ steps.ver.outputs.version }}" \
+              -a stem=latexmath \
+              genres/index.adoc \
+              -o dist/genres/index.html
+          fi
+
       - name: Generate LLM files
         run: |
           bash scripts/generate-llm-files.sh . dist "${{ steps.ver.outputs.version }}"

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -94,6 +94,17 @@ jobs:
               -o source/genres/taxonomy.html
           fi
 
+      - name: Build genre packs index with AsciiDoctor
+        run: |
+          if [ -f source/genres/index.adoc ]; then
+            asciidoctor \
+              -a revnumber="${{ steps.version.outputs.version }}" \
+              -a ugas-version="v${{ steps.version.outputs.version }}" \
+              -a stem=latexmath \
+              source/genres/index.adoc \
+              -o source/genres/index.html
+          fi
+
       - name: Generate LLM files
         run: |
           bash source/scripts/generate-llm-files.sh source source "v${{ steps.version.outputs.version }}"
@@ -141,7 +152,7 @@ jobs:
           if grep -qF "[v${VERSION}]" docs/README.md; then
             echo "Version v${VERSION} already in README, skipping"
           else
-            ROW="| [v${VERSION}](v${VERSION}/) | ${DATE} | Pre-release | [Spec](v${VERSION}/index.html) · [MD](v${VERSION}/SPEC.md) | [Schemas](v${VERSION}/schemas/) |"
+            ROW="| [v${VERSION}](v${VERSION}/) | ${DATE} | Pre-release | [Spec](v${VERSION}/index.html) · [MD](v${VERSION}/SPEC.md) · [Templates](v${VERSION}/genres/) | [Schemas](v${VERSION}/schemas/) |"
             sed -i "s|<!-- NEW_VERSION -->|${ROW}\n<!-- NEW_VERSION -->|" docs/README.md
           fi
 
@@ -176,6 +187,7 @@ jobs:
           - \`SPEC.adoc\` → \`v${VERSION}/index.html\` (HTML with AsciiDoctor)
           - \`SPEC.adoc\` → \`v${VERSION}/SPEC.md\` (Markdown via Pandoc)
           - \`schemas/**/*\` → \`v${VERSION}/schemas/\`
+          - \`genres/**\` → \`v${VERSION}/genres/\` (genre pack templates + rendered specs, index, taxonomy)
           - \`llms.txt\` → root (LLM discoverability)
           - \`llms-full.txt\` → root (complete LLM context)"
           fi

--- a/genres/index.adoc
+++ b/genres/index.adoc
@@ -1,0 +1,78 @@
+= UGAS Genre Packs
+Mickael Bonfill <jbltx>
+:revnumber: 1.0.0-draft.1
+:ugas-version: v1.0.0-draft.1
+:doctype: book
+:toc: left
+:toc-title: Table of Contents
+:toclevels: 4
+:stem: latexmath
+:source-highlighter: highlight.js
+:icons: font
+:sectanchors:
+:sectlinks:
+:docinfo: shared
+
+[[overview]]
+== Overview
+
+The core link:../index.html[UGAS specification] is deliberately genre-agnostic. A *genre
+pack* makes it practical to bootstrap a real game — by humans or AI agents — by bundling two
+*additive* artifacts per genre:
+
+. an *additional spec* that extends (never replaces) the core spec with genre-specific
+  Attributes, Tags, Abilities, and Effects; and
+. a *template*: ready-to-use, schema-conformant entity files under the pack's `entities/`
+  directory.
+
+This page is the navigable index of the packs published with this version. For the full map
+of genres and subgenres — and how the prioritized packs are positioned within the broader
+space — see the link:taxonomy.html[genre taxonomy].
+
+[IMPORTANT]
+====
+This index and the genre packs it links are *additive companions* to the core
+specification. A genre `spec.adoc` extends the core spec with genre-specific definitions; it
+MUST NOT redefine, override, or contradict any concept in the
+link:../index.html[core UGAS specification]. The link:taxonomy.html[taxonomy] itself is
+*non-normative*.
+====
+
+[[available-packs]]
+== Available packs
+
+Each pack is a self-contained directory: a rendered genre spec plus a `entities/` folder of
+schema-conformant template files you can copy and extend.
+
+[cols="1,2,1",options="header"]
+|===
+| Pack | Scope | Template entities
+
+| link:rpg/index.html[*RPG*]
+| Role-Playing — seeded by the Action-RPG case study
+| `rpg/entities/`
+
+| link:racing/index.html[*Racing*]
+| Racing (Forza-style) — seeded by the Racing case study
+| `racing/entities/`
+
+| link:action/index.html[*Action / Action-Adventure*]
+| Platformer-led action — seeded by the Platformer case study
+| `action/entities/`
+|===
+
+[[using-a-pack]]
+== Using a pack
+
+. Open a pack's rendered spec (the *Pack* column above) to understand its Attributes, Tags,
+  Abilities, and Effects.
+. Copy that pack's `entities/` directory into your project as a starting point, then keep,
+  rename, or extend the entities — they are schema-conformant and validate against the same
+  `schemas/*.json` as the core spec.
+. Add new states as `State.*` tags granted by Effects (never mutate tags directly), and new
+  mechanics as Effects + Abilities.
+
+Users and AI agents (e.g. the `ugas-schema-author` skill) can load a pack's `entities/`
+directly. For machine consumption, the site root publishes `llms.txt` (a discoverability
+index) and `llms-full.txt` (the complete context: the spec plus every schema, example, and
+genre-pack entity in one file).

--- a/llms.txt
+++ b/llms.txt
@@ -27,6 +27,16 @@ The specification covers four pillars: Attributes (numeric state with a modifier
 - [Fireball Ability](%%UGAS_VERSION%%/schemas/examples/fireball_ability.yaml): Offensive ability with tag requirements
 - [Tag Registry](%%UGAS_VERSION%%/schemas/examples/tag_registry.yaml): Example tag hierarchy
 
+## Genre Packs (templates)
+
+Additive, copy-and-extend starter kits per genre: a genre spec that extends (never replaces) the core spec, plus schema-conformant template entities you can load directly.
+
+- [Genre Packs index](%%UGAS_VERSION%%/genres/index.html): Navigable landing page listing every published genre pack
+- [Genre taxonomy](%%UGAS_VERSION%%/genres/taxonomy.html): Non-normative map of game genres/subgenres that scopes the pack work
+- [RPG pack spec](%%UGAS_VERSION%%/genres/rpg/spec.adoc): Role-Playing genre extension; template entities under %%UGAS_VERSION%%/genres/rpg/entities/
+- [Racing pack spec](%%UGAS_VERSION%%/genres/racing/spec.adoc): Racing (Forza-style) genre extension; template entities under %%UGAS_VERSION%%/genres/racing/entities/
+- [Action pack spec](%%UGAS_VERSION%%/genres/action/spec.adoc): Action / Action-Adventure genre extension; template entities under %%UGAS_VERSION%%/genres/action/entities/
+
 ## Optional
 
 - [Schema README](%%UGAS_VERSION%%/schemas/README.md): Documentation for schema usage and validation

--- a/scripts/generate-llm-files.sh
+++ b/scripts/generate-llm-files.sh
@@ -74,5 +74,32 @@ for example_file in "${SOURCE_DIR}"/schemas/examples/*.yaml; do
   printf '```\n' >> "${OUTPUT_DIR}/llms-full.txt"
 done
 
+if compgen -G "${SOURCE_DIR}/genres/*/entities/*.yaml" > /dev/null; then
+  cat >> "${OUTPUT_DIR}/llms-full.txt" <<'HEADER'
+
+---
+
+# Genre Pack Templates
+
+The following YAML files are schema-conformant template entities from the genre packs. Copy a pack's entities as a starting point for a new game in that genre.
+
+HEADER
+
+  for genre_dir in "${SOURCE_DIR}"/genres/*/; do
+    genre="$(basename "${genre_dir}")"
+    case "${genre}" in _*) continue ;; esac
+    [ -d "${genre_dir}entities" ] || continue
+    compgen -G "${genre_dir}entities/*.yaml" > /dev/null || continue
+    printf '\n## Genre Pack: %s\n' "${genre}" >> "${OUTPUT_DIR}/llms-full.txt"
+    for entity_file in "${genre_dir}entities"/*.yaml; do
+      filename="$(basename "${entity_file}")"
+      pretty_name="$(echo "${filename%.yaml}" | tr '_' ' ' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1')"
+      printf '\n### %s\n\n```yaml\n' "${pretty_name}" >> "${OUTPUT_DIR}/llms-full.txt"
+      cat "${entity_file}" >> "${OUTPUT_DIR}/llms-full.txt"
+      printf '```\n' >> "${OUTPUT_DIR}/llms-full.txt"
+    done
+  done
+fi
+
 echo "Generated: ${OUTPUT_DIR}/SPEC.md"
 echo "Generated: ${OUTPUT_DIR}/llms-full.txt"


### PR DESCRIPTION
## Summary

Makes the genre packs reachable from the two published-docs entry points — the docs README and `llms.txt` — so humans and AI agents can find the templates from the site root.

- **`genres/index.adoc`** (new) — a rendered genre-packs landing page that lists the shipped packs (rpg, racing, action), each linking its rendered `index.html`, plus the taxonomy and core spec. Built by both docs workflows to `genres/index.html`; links resolve identically on the published site (`vX/genres/`) and Cloudflare preview (`genres/`).
- **`llms.txt`** — adds a "Genre Packs (templates)" section pointing at the index, taxonomy, and each pack's spec + `entities/` path.
- **`scripts/generate-llm-files.sh`** — appends a "Genre Pack Templates" section to `llms-full.txt`, inlining every pack's entity YAML (excludes `_template`).
- **`preview-docs.yml` / `publish-docs.yml`** — build `genres/index.adoc`; publish README version row gains a `[Templates](vX/genres/)` link; publish PR body notes the genres tree.
- Changeset: `'ugas': patch`.

Refs #28.

## Test plan

- [x] `asciidoctor --failure-level=WARN genres/index.adoc` builds with no warnings
- [x] `python scripts/validate_schema_examples.py` still passes (39 snippets; the `.adoc` is ignored by the validator)
- [x] New `generate-llm-files.sh` loop tested in isolation — emits well-formed sections for rpg/racing/action, skips `_template`
- [x] CI `preview-docs` produces `dist/genres/index.html` and the Cloudflare preview serves `…/genres/index.html`
- [x] CI `validate-schema-examples` stays green