### PR TITLE
feat: add Shooter genre pack (genres/shooter)

### DIFF
--- a/.changeset/genre-pack-shooter.md
+++ b/.changeset/genre-pack-shooter.md
@@ -1,0 +1,5 @@
+---
+'ugas': minor
+---
+
+[Added] Shooter genre pack (`genres/shooter/`): an additive first/third-person shooter specification plus a schema-conformant template — `ShooterCombatSet` (survivability with regenerating shields, weapon-handling feel stats, magazine + reserve ammo economy), a shooter tag taxonomy (weapon loadout, hitzones, teams), a fire/reload/aim gunplay loop with cost-gated and rate-paced firing, two-channel accuracy aggregation (Aim × Attachments), custom Executions for stateful reload and hit resolution (shields, headshot multiplier, range falloff), and a worked aiming-soldier controller. Designed from first principles as a ready-to-extend pack (#33).

--- a/genres/README.md
+++ b/genres/README.md
@@ -60,3 +60,4 @@ assistant skill) can load a pack's `entities/` directly as a starting point and 
 | `rpg` | Role-Playing (RPG) — seeded by the ARPG case study | [`rpg/spec.adoc`](rpg/spec.adoc) |
 | `racing` | Racing (Forza-style) — seeded by the Racing case study | [`racing/spec.adoc`](racing/spec.adoc) |
 | `action` | Action / Action-Adventure — seeded by the Platformer case study | [`action/spec.adoc`](action/spec.adoc) |
+| `shooter` | Shooter (FPS/TPS) — gunplay, ammo economy, hit resolution | [`shooter/spec.adoc`](shooter/spec.adoc) |

--- a/genres/index.adoc
+++ b/genres/index.adoc
@@ -59,6 +59,10 @@ schema-conformant template files you can copy and extend.
 | link:action/index.html[*Action / Action-Adventure*]
 | Platformer-led action — seeded by the Platformer case study
 | `action/entities/`
+
+| link:shooter/index.html[*Shooter*]
+| First/third-person gunplay — ammo economy and hit resolution
+| `shooter/entities/`
 |===
 
 [[using-a-pack]]

--- a/genres/shooter/README.md
+++ b/genres/shooter/README.md
@@ -1,0 +1,43 @@
+# UGAS Genre Pack: Shooter
+
+> First/third-person gunplay: survivability with regenerating shields, weapon-handling "feel"
+> stats, an ammo economy (magazine + reserve), aim-down-sights, and hitscan damage with hitzone
+> multipliers — the core of the wider shooter family (FPS, TPS, hero shooter, battle royale).
+
+This pack is a copy-and-extend starting point for shooters. It is *additive*: it defines
+genre-specific Attributes, Tags, Abilities, and Effects on top of the core UGAS spec and never
+redefines a core concept. There is no dedicated case study for shooters in the core spec, so the
+pack is designed from first principles and grounded in the genre's standard mechanics.
+
+## What's in this pack
+
+| File | Purpose |
+|------|---------|
+| `spec.adoc` | Additional Shooter specification — extends, never replaces, the core spec |
+| `entities/attribute_set.yaml` | `ShooterCombatSet`: survivability, weapon-handling feel, ammo economy |
+| `entities/tag_registry.yaml` | Shooter tags: weapon-handling states, loadout, hitzones, teams |
+| `entities/effect_equip_rifle.yaml` | `GE_EquipRifle`: grants the weapon-loadout tags |
+| `entities/effect_ads.yaml` | `GE_ADS`: tighter cone + slower movement while aiming (Aim channel) |
+| `entities/effect_attachment_barrel.yaml` | `GE_AttachmentBarrel`: cone + range upgrade (Attachments channel) |
+| `entities/effect_reloading.yaml` | `GE_Reloading`: in-progress reload state that blocks fire/aim |
+| `entities/effect_reload.yaml` | `GE_Reload`: instant magazine transfer via a custom Execution |
+| `entities/effect_ballistic_damage.yaml` | `GE_BallisticDamage`: hit resolution (shields, hitzone, falloff) |
+| `entities/ability_fire.yaml` | `GA_Fire`: trace + apply damage; costs ammo, paced by a cooldown |
+| `entities/ability_reload.yaml` | `GA_Reload`: enter reloading, wait, transfer rounds |
+| `entities/ability_aim.yaml` | `GA_Aim`: hold to aim down sights |
+| `entities/gameplay_controller.yaml` | Worked example: a soldier aiming a rifle with a barrel attachment |
+
+## How to use
+
+1. Read `spec.adoc` for the genre-specific design (especially the gunplay loop and the two-channel
+   accuracy aggregation).
+2. Copy the entity files in `entities/` into your project and adapt them — change the rifle base
+   values in `attribute_set.yaml`, add new weapon `GE_Equip*` effects, or wire the two `ExecCalc_*`
+   hooks (`ExecCalc_MagazineReload`, `ExecCalc_HitResolution`) in your engine.
+3. They validate against the core `schemas/*.yaml`, so AI agents (e.g. the `ugas-schema-author`
+   skill) can load and extend them directly.
+4. Run `python scripts/validate_schema_examples.py` after changes.
+
+## Published spec
+
+<!-- Link to the built HTML once published, e.g. v<version>/genres/shooter/index.html -->

--- a/genres/shooter/entities/ability_aim.yaml
+++ b/genres/shooter/entities/ability_aim.yaml
@@ -1,0 +1,26 @@
+# Aim down sights: hold to apply GE_ADS (tighter cone, slower movement, State.Aiming), release to
+# remove it. Same hold-then-WaitInputRelease shape as the platformer jump. Cannot aim mid-reload.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
+Name: GA_Aim
+Tags:
+  AbilityTags:
+    - Ability.Type.Aim
+  ActivationRequiredTags:
+    - Weapon.Equipped
+  ActivationBlockedTags:
+    - State.Reloading
+Tasks:
+  - Type: ApplyEffectToOwner
+    Params:
+      EffectClass: GE_ADS
+  - Type: WaitInputRelease
+    Params:
+      InputID: Aim
+  - Type: RemoveEffectFromOwner
+    Params:
+      EffectClass: GE_ADS
+Metadata:
+  DisplayName: Aim Down Sights
+  Description: Hold to aim for a tighter bullet cone at the cost of movement speed
+  Icon: ui/icons/aim.png

--- a/genres/shooter/entities/ability_fire.yaml
+++ b/genres/shooter/entities/ability_fire.yaml
@@ -1,0 +1,30 @@
+# Primary fire: trace under the crosshair and apply ballistic damage to the hit target.
+# Costs one round (GE_FireCost: Ammo -1) - the cost gate is what prevents firing on an empty
+# magazine - and goes on a per-shot cooldown (GE_FireCooldown, duration = 1 / FireRate) that paces
+# the automatic fire rate. Cannot fire mid-reload. GE_FireCost and GE_FireCooldown are trivial
+# (a flat resource cost and a cooldown tag) and are referenced by name rather than shipped as files.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
+Name: GA_Fire
+Tags:
+  AbilityTags:
+    - Ability.Type.Fire
+    - DamageType.Ballistic
+  ActivationRequiredTags:
+    - Weapon.Equipped
+  ActivationBlockedTags:
+    - State.Reloading
+Cost: GE_FireCost
+Cooldown: GE_FireCooldown
+Tasks:
+  - Type: WaitTargetData
+    Params:
+      TargetingMethod: HitscanTrace
+      MaxRange: 200.0
+  - Type: ApplyEffectToTarget
+    Params:
+      EffectClass: GE_BallisticDamage
+Metadata:
+  DisplayName: Fire
+  Description: Fire the equipped weapon at the target under the crosshair
+  Icon: ui/icons/fire.png

--- a/genres/shooter/entities/ability_reload.yaml
+++ b/genres/shooter/entities/ability_reload.yaml
@@ -1,0 +1,28 @@
+# Reload: enter the reloading state, wait the reload window, then transfer rounds from the reserve
+# into the magazine. Blocked while already reloading. The "only reload if not full and the reserve
+# is non-empty" check (Ammo < MagazineSize AND ReserveAmmo > 0) is evaluated in activation logic,
+# since attribute comparisons cannot be expressed as activation tags.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
+Name: GA_Reload
+Tags:
+  AbilityTags:
+    - Ability.Type.Reload
+  ActivationRequiredTags:
+    - Weapon.Equipped
+  ActivationBlockedTags:
+    - State.Reloading
+Tasks:
+  - Type: ApplyEffectToOwner
+    Params:
+      EffectClass: GE_Reloading
+  - Type: WaitDelay
+    Params:
+      Duration: 2.0
+  - Type: ApplyEffectToOwner
+    Params:
+      EffectClass: GE_Reload
+Metadata:
+  DisplayName: Reload
+  Description: Reload the equipped weapon, drawing rounds from the reserve
+  Icon: ui/icons/reload.png

--- a/genres/shooter/entities/attribute_set.yaml
+++ b/genres/shooter/entities/attribute_set.yaml
@@ -1,0 +1,144 @@
+# Shooter combat attribute set: survivability, the weapon-handling "feel" stats, and the
+# ammo economy. Extends the core spec's attribute model (no core attribute is redefined here).
+# Base values describe a default automatic rifle so the set is playable as shipped.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/attribute_set.json
+Name: ShooterCombatSet
+Attributes:
+  # --- Survivability (shield absorbs first, then health; both regenerate out of combat) ---
+  - Name: MaxHealth
+    DefaultBaseValue: 100.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Maximum Health
+      UICategory: Survivability
+  - Name: Health
+    DefaultBaseValue: 100.0
+    Category: Resource
+    Clamping:
+      Min: 0
+      Max: MaxHealth
+    ReplicationMode: All
+    Metadata:
+      DisplayName: Health
+      Description: Hit points; reaching 0 is a down/kill. Damage spills here after Shield is depleted
+      UICategory: Survivability
+  - Name: MaxShield
+    DefaultBaseValue: 50.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Maximum Shield
+      UICategory: Survivability
+  - Name: Shield
+    DefaultBaseValue: 50.0
+    Category: Resource
+    Clamping:
+      Min: 0
+      Max: MaxShield
+    ReplicationMode: All
+    Metadata:
+      DisplayName: Shield
+      Description: Regenerating overshield that absorbs incoming damage before Health
+      UICategory: Survivability
+
+  # --- Movement ---
+  - Name: MoveSpeed
+    DefaultBaseValue: 600.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Movement Speed
+      Description: Ground movement speed; lowered while aiming down sights (GE_ADS)
+      UICategory: Movement
+
+  # --- Weapon handling (the gunplay "feel" stats; target of the damage/accuracy channels) ---
+  - Name: WeaponDamage
+    DefaultBaseValue: 25.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Weapon Damage
+      Description: Fully-aggregated per-shot damage read by GE_BallisticDamage (after all channels resolve)
+      UICategory: Weapon
+  - Name: FireRate
+    DefaultBaseValue: 10.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Fire Rate
+      Description: Rounds per second; the per-shot cooldown (GE_FireCooldown) is 1 / FireRate
+      UICategory: Weapon
+  - Name: Spread
+    DefaultBaseValue: 2.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Spread
+      Description: Bullet-cone half-angle in degrees; tightened by aiming (Aim channel) and attachments (Attachments channel)
+      UICategory: Weapon
+  - Name: HeadshotMultiplier
+    DefaultBaseValue: 2.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Headshot Multiplier
+      Description: Damage multiplier applied by the hit-resolution calc when the target is hit on Hitzone.Head
+      UICategory: Weapon
+  - Name: EffectiveRange
+    DefaultBaseValue: 50.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Effective Range
+      Description: Distance in metres before damage falloff begins; extended by barrel attachments
+      UICategory: Weapon
+
+  # --- Ammo economy (magazine spent by firing, refilled from the reserve on reload) ---
+  - Name: MagazineSize
+    DefaultBaseValue: 30.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Magazine Size
+      Description: Rounds per magazine; the upper clamp on Ammo
+      UICategory: Ammo
+  - Name: Ammo
+    DefaultBaseValue: 30.0
+    Category: Resource
+    Clamping:
+      Min: 0
+      Max: MagazineSize
+    ReplicationMode: All
+    Metadata:
+      DisplayName: Loaded Ammo
+      Description: Rounds in the current magazine; spent by GA_Fire (GE_FireCost), refilled by GA_Reload
+      UICategory: Ammo
+  - Name: ReserveAmmo
+    DefaultBaseValue: 90.0
+    Category: Resource
+    Clamping:
+      Min: 0
+    ReplicationMode: All
+    Metadata:
+      DisplayName: Reserve Ammo
+      Description: Spare rounds drawn into the magazine on reload
+      UICategory: Ammo
+  - Name: ReloadTime
+    DefaultBaseValue: 2.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Reload Time
+      Description: Seconds to complete a reload; the GA_Reload wait window
+      UICategory: Ammo
+
+  # --- Runtime state (driven each frame by the simulation / hit-resolution calc) ---
+  - Name: DistanceToTarget
+    DefaultBaseValue: 0.0
+    Category: Meta
+    Metadata:
+      DisplayName: Distance To Target
+      Description: Live distance in metres to the traced target; compared against EffectiveRange for falloff
+      UICategory: Telemetry
+  - Name: EffectiveDamage
+    DefaultBaseValue: 0.0
+    Category: Meta
+    Metadata:
+      DisplayName: Effective Damage
+      Description: Output of ExecCalc_HitResolution after hitzone multiplier and range falloff; for telemetry/UI
+      UICategory: Telemetry
+Metadata:
+  DisplayName: Shooter Combat Set
+  Description: Survivability, weapon-handling feel stats, ammo economy, and runtime telemetry for a first/third-person shooter

--- a/genres/shooter/entities/effect_ads.yaml
+++ b/genres/shooter/entities/effect_ads.yaml
@@ -1,0 +1,25 @@
+# Aim down sights: held while the aim input is down (applied/removed by GA_Aim).
+# Tightens the bullet cone and slows movement. Both modifiers use the additive-within-channel
+# convention: factor = 1 + Value, so Spread x (1 - 0.75) = x0.25 and MoveSpeed x (1 - 0.3) = x0.70.
+# Spread sits in the Aim channel; the Attachments channel (GE_AttachmentBarrel) multiplies across it.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_ADS
+DurationPolicy: Infinite
+Modifiers:
+  - Attribute: Spread
+    Operation: Multiply
+    Magnitude:
+      Type: ScalableFloat
+      Value: -0.75
+    Channel: Aim
+  - Attribute: MoveSpeed
+    Operation: Multiply
+    Magnitude:
+      Type: ScalableFloat
+      Value: -0.3
+    Channel: Aim
+GrantedTags:
+  - State.Aiming
+GameplayCues:
+  - GameplayCue.Weapon.ADS

--- a/genres/shooter/entities/effect_attachment_barrel.yaml
+++ b/genres/shooter/entities/effect_attachment_barrel.yaml
@@ -1,0 +1,22 @@
+# Barrel/muzzle attachment: a loadout upgrade that tightens the cone and extends range.
+# Infinite while fitted. The Spread modifier sits in the Attachments channel - a different channel
+# from GE_ADS's Aim channel - so the two multiply: base Spread x Aim x Attachments (see the
+# worked example in gameplay_controller.yaml). EffectiveRange is a flat additive bonus.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_AttachmentBarrel
+DurationPolicy: Infinite
+Modifiers:
+  - Attribute: Spread
+    Operation: Multiply
+    Magnitude:
+      Type: ScalableFloat
+      Value: -0.5
+    Channel: Attachments
+  - Attribute: EffectiveRange
+    Operation: Add
+    Magnitude:
+      Type: ScalableFloat
+      Value: 30.0
+GrantedTags:
+  - Weapon.Attachment.Barrel

--- a/genres/shooter/entities/effect_ballistic_damage.yaml
+++ b/genres/shooter/entities/effect_ballistic_damage.yaml
@@ -1,0 +1,13 @@
+# Damage from a single bullet hit, applied to the traced target by GA_Fire. Shooter damage is not a
+# single static subtraction: it couples the source's aggregated WeaponDamage with range falloff
+# (DistanceToTarget vs EffectiveRange), the hitzone multiplier (x HeadshotMultiplier on Hitzone.Head),
+# and shield-before-health absorption - so it runs through a custom Execution. The calc honors
+# Immunity.Ballistic targets and writes EffectiveDamage (Meta) for telemetry/UI.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_BallisticDamage
+DurationPolicy: Instant
+Executions:
+  - CalculatorClass: ExecCalc_HitResolution
+GameplayCues:
+  - GameplayCue.Weapon.Impact

--- a/genres/shooter/entities/effect_equip_rifle.yaml
+++ b/genres/shooter/entities/effect_equip_rifle.yaml
@@ -1,0 +1,13 @@
+# Equips the default automatic rifle. Infinite; grants the weapon-loadout tags that gate the
+# fire/reload/aim abilities. The rifle's stat block is the ShooterCombatSet base values, so this
+# effect carries no modifiers - swapping weapons means swapping which equip effect is active.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_EquipRifle
+DurationPolicy: Infinite
+GrantedTags:
+  - Weapon.Equipped
+  - Weapon.Type.Rifle
+  - Weapon.FireMode.Auto
+GameplayCues:
+  - GameplayCue.Weapon.Equip

--- a/genres/shooter/entities/effect_reload.yaml
+++ b/genres/shooter/entities/effect_reload.yaml
@@ -1,0 +1,10 @@
+# Magazine transfer, applied instantly at the end of the reload. The amount moved depends on the
+# live Ammo, MagazineSize, and ReserveAmmo, so it cannot be a static modifier - it runs through a
+# custom Execution that tops the magazine up to MagazineSize and decrements ReserveAmmo by the
+# rounds loaded (capped by what's left in reserve).
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_Reload
+DurationPolicy: Instant
+Executions:
+  - CalculatorClass: ExecCalc_MagazineReload

--- a/genres/shooter/entities/effect_reloading.yaml
+++ b/genres/shooter/entities/effect_reloading.yaml
@@ -1,0 +1,14 @@
+# In-progress reload state. HasDuration so it self-expires after the reload window; grants
+# State.Reloading, which blocks GA_Fire and GA_Aim. GA_Reload applies this, waits the duration,
+# then applies GE_Reload (the instant magazine transfer). Duration mirrors the ReloadTime attribute.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_Reloading
+DurationPolicy: HasDuration
+Duration:
+  Type: ScalableFloat
+  Value: 2.0
+GrantedTags:
+  - State.Reloading
+GameplayCues:
+  - GameplayCue.Weapon.Reload

--- a/genres/shooter/entities/gameplay_controller.yaml
+++ b/genres/shooter/entities/gameplay_controller.yaml
@@ -1,0 +1,90 @@
+# Worked example: a player aiming a rifle that has a barrel attachment fitted.
+# CurrentValue columns show the result of the three active infinite effects below. The Spread
+# aggregation is the genre's signature: two channels multiply across each other.
+#   Spread:         base 2.0 x Aim(1 - 0.75 = 0.25) x Attachments(1 - 0.5 = 0.50) = 0.25
+#   MoveSpeed:      base 600 x Aim(1 - 0.3 = 0.70)                                = 420.0
+#   EffectiveRange: base 50 + 30 (barrel)                                         = 80.0
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_controller.json
+OwnerActor:
+  ActorID: Soldier_FPS_01
+  ActorType: PlayerCharacter
+AttributeSets:
+  - Name: ShooterCombatSet
+    Attributes:
+      - Name: MaxHealth
+        BaseValue: 100.0
+        CurrentValue: 100.0
+      - Name: Health
+        BaseValue: 100.0
+        CurrentValue: 100.0
+      - Name: MaxShield
+        BaseValue: 50.0
+        CurrentValue: 50.0
+      - Name: Shield
+        BaseValue: 50.0
+        CurrentValue: 50.0
+      - Name: MoveSpeed
+        BaseValue: 600.0
+        CurrentValue: 420.0
+      - Name: WeaponDamage
+        BaseValue: 25.0
+        CurrentValue: 25.0
+      - Name: FireRate
+        BaseValue: 10.0
+        CurrentValue: 10.0
+      - Name: Spread
+        BaseValue: 2.0
+        CurrentValue: 0.25
+      - Name: HeadshotMultiplier
+        BaseValue: 2.0
+        CurrentValue: 2.0
+      - Name: EffectiveRange
+        BaseValue: 50.0
+        CurrentValue: 80.0
+      - Name: MagazineSize
+        BaseValue: 30.0
+        CurrentValue: 30.0
+      - Name: Ammo
+        BaseValue: 30.0
+        CurrentValue: 30.0
+      - Name: ReserveAmmo
+        BaseValue: 90.0
+        CurrentValue: 90.0
+      - Name: ReloadTime
+        BaseValue: 2.0
+        CurrentValue: 2.0
+GrantedAbilities:
+  - AbilityClass: GA_Fire
+    Level: 1
+    InputID: Fire
+  - AbilityClass: GA_Reload
+    Level: 1
+    InputID: Reload
+  - AbilityClass: GA_Aim
+    Level: 1
+    InputID: Aim
+ActiveEffects:
+  - Handle: eff-equip-rifle
+    EffectClass: GE_EquipRifle
+    Duration: -1
+  - Handle: eff-attachment-barrel
+    EffectClass: GE_AttachmentBarrel
+    Duration: -1
+  - Handle: eff-ads
+    EffectClass: GE_ADS
+    Duration: -1
+OwnedTags:
+  - State.Alive
+  - Team.Friendly
+  - Weapon.Equipped
+  - Weapon.Type.Rifle
+  - Weapon.FireMode.Auto
+  - Weapon.Attachment.Barrel
+  - State.Aiming
+ReplicationMode: Mixed
+bIsActive: true
+Metadata:
+  DisplayName: FPS Soldier (aiming, rifle + barrel)
+  Description: Worked-example shooter character showing two-channel Spread aggregation while aiming
+  DebugCategory: shooter-pack-example

--- a/genres/shooter/entities/tag_registry.yaml
+++ b/genres/shooter/entities/tag_registry.yaml
@@ -1,0 +1,89 @@
+# Shooter genre tag taxonomy. ADDITIVE: introduces genre-specific tags only.
+# It does not redefine the core lifecycle tags (State.Alive / State.Combat / State.Dead) -
+# those are referenced by the pack's entities, not declared here.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_tag.json
+Tags:
+  # --- Weapon-handling states (granted by Effects; tag ownership follows responsibility) ---
+  - Tag: State.Aiming
+    Description: Aiming down sights; granted by GE_ADS, removed when the aim input is released
+    AllowMultiple: false
+  - Tag: State.Reloading
+    Description: A reload is in progress; granted by GE_Reloading, blocks firing and aiming
+    AllowMultiple: false
+  - Tag: State.Sprinting
+    Description: Tactical sprint state (owned by the movement system); documented for a sprint extension
+    AllowMultiple: false
+
+  # --- Weapon classification & loadout (granted by equip / attachment Effects) ---
+  - Tag: Weapon.Equipped
+    Description: A weapon is equipped and ready; gate for the fire/reload/aim abilities
+    AllowMultiple: false
+  - Tag: Weapon.Type.Rifle
+    Description: Automatic rifle
+    AllowMultiple: false
+  - Tag: Weapon.Type.Pistol
+    Description: Sidearm
+    AllowMultiple: false
+  - Tag: Weapon.Type.Shotgun
+    Description: Close-range spread weapon
+    AllowMultiple: false
+  - Tag: Weapon.Type.Sniper
+    Description: Long-range precision rifle
+    AllowMultiple: false
+  - Tag: Weapon.FireMode.Auto
+    Description: Fully automatic fire while the trigger is held
+    AllowMultiple: false
+  - Tag: Weapon.FireMode.SemiAuto
+    Description: One shot per trigger pull
+    AllowMultiple: false
+  - Tag: Weapon.FireMode.Burst
+    Description: A fixed burst of rounds per trigger pull
+    AllowMultiple: false
+  - Tag: Weapon.Attachment.Barrel
+    Description: A muzzle/barrel attachment is fitted; granted by GE_AttachmentBarrel
+    AllowMultiple: false
+
+  # --- Ability classification ---
+  - Tag: Ability.Type.Fire
+    Description: Primary fire ability
+    AllowMultiple: false
+  - Tag: Ability.Type.Reload
+    Description: Reload ability
+    AllowMultiple: false
+  - Tag: Ability.Type.Aim
+    Description: Aim-down-sights ability
+    AllowMultiple: false
+  - Tag: Ability.Type.Movement
+    Description: Locomotion ability (sprint, slide, vault)
+    AllowMultiple: false
+
+  # --- Damage types ---
+  - Tag: DamageType.Ballistic
+    Description: Kinetic projectile / hitscan damage
+    AllowMultiple: false
+  - Tag: DamageType.Explosive
+    Description: Area damage from grenades and rockets
+    AllowMultiple: false
+
+  # --- Hitzones (drive the headshot damage multiplier) ---
+  - Tag: Hitzone.Head
+    Description: Hit landed on the head; the hit-resolution calc applies HeadshotMultiplier
+    AllowMultiple: false
+  - Tag: Hitzone.Body
+    Description: Hit landed on the torso; baseline damage
+    AllowMultiple: false
+  - Tag: Hitzone.Limb
+    Description: Hit landed on a limb; typically reduced damage
+    AllowMultiple: false
+
+  # --- Teams & immunity ---
+  - Tag: Team.Friendly
+    Description: Same team as the source; used to skip friendly fire
+    AllowMultiple: false
+  - Tag: Team.Hostile
+    Description: Opposing team; a valid damage target
+    AllowMultiple: false
+  - Tag: Immunity.Ballistic
+    Description: Ignores incoming ballistic damage (e.g. spawn protection); honored by the hit-resolution calc
+    AllowMultiple: false

--- a/genres/shooter/spec.adoc
+++ b/genres/shooter/spec.adoc
@@ -1,0 +1,186 @@
+= UGAS Genre Pack: Shooter
+Mickael Bonfill <jbltx>
+:revnumber: 1.0.0-draft.1
+:ugas-version: v1.0.0-draft.1
+:doctype: book
+:toc: left
+:toc-title: Table of Contents
+:toclevels: 4
+:stem: latexmath
+:source-highlighter: highlight.js
+:icons: font
+:sectanchors:
+:sectlinks:
+:docinfo: shared
+
+[[overview]]
+== Overview
+
+This genre pack targets *shooters* in the Call of Duty / Halo / Apex / Counter-Strike mould: a
+character defined by *weapon-handling* attributes, an *ammo economy* (magazine plus reserve), a
+*fire / reload / aim* gunplay loop, and *hit resolution* that couples regenerating shields, hitzone
+multipliers (headshots), and range falloff.
+
+Unlike the Platformer, Racing, and ARPG packs, the core specification ships no dedicated shooter
+case study, so this pack is designed from first principles. It still leans entirely on core
+constructs — the modifier `Channel` mechanism (link:../../SPEC.adoc[core spec] §5.3) for accuracy
+aggregation, custom `Executions` for stateful reload and damage, and effect-granted tags for the
+weapon-handling state machine.
+
+The first-person shooter is the concrete seed, but the same pieces generalize to the wider
+*shooter* family — third-person, hero shooter, battle royale — which layer classes, loot, and
+objectives on top of this gunplay-and-loadout core.
+
+[[relationship-to-core-spec]]
+== Relationship to the core specification
+
+This document is *additive*. It defines genre-specific Attributes, Tags, Abilities, and
+Effects on top of the core Universal Gameplay Ability System specification.
+
+* It MUST NOT redefine, override, or contradict any concept in the core spec.
+* All entities in `entities/` validate against the same `schemas/*.json` as the core.
+* It *reuses* the core lifecycle tags (`State.Alive`, `State.Combat`, `State.Dead`) by reference,
+  and adds shooter-specific states (`State.Aiming`, `State.Reloading`, …).
+* Weapon-handling state is mutated *only through Effects* (core spec §3.1) — abilities never write
+  tags directly — and the accuracy stacking is the core modifier `Channel` mechanism, not a new
+  construct.
+
+[[genre-attributes]]
+== Genre Attributes
+
+Defined in `entities/attribute_set.yaml` as the `ShooterCombatSet` set. The base values describe a
+default automatic rifle, so the set is playable as shipped.
+
+[cols="1,1,3",options="header"]
+|===
+| Attribute | Category | Role
+
+| `MaxHealth` / `Health` | Statistic / Resource | `Health` is clamped to `[0, MaxHealth]`; damage spills here once `Shield` is gone.
+| `MaxShield` / `Shield` | Statistic / Resource | Regenerating overshield; absorbs incoming damage before `Health`.
+| `MoveSpeed` | Statistic | Ground movement speed; lowered while aiming down sights.
+| `WeaponDamage` | Statistic | Fully-aggregated per-shot damage read by `GE_BallisticDamage`.
+| `FireRate` | Statistic | Rounds per second; the per-shot cooldown is latexmath:[1 / \text{FireRate}].
+| `Spread` | Statistic | Bullet-cone half-angle in degrees; tightened by the `Aim` and `Attachments` channels.
+| `HeadshotMultiplier` | Statistic | Damage multiplier applied on a `Hitzone.Head` hit.
+| `EffectiveRange` | Statistic | Distance before damage falloff begins; extended by barrel attachments.
+| `MagazineSize` | Statistic | Rounds per magazine; the upper clamp on `Ammo`.
+| `Ammo` | Resource | Loaded rounds; clamped to `[0, MagazineSize]`, spent by firing.
+| `ReserveAmmo` | Resource | Spare rounds drawn into the magazine on reload.
+| `ReloadTime` | Statistic | Seconds to complete a reload; the `GA_Reload` wait window.
+| `DistanceToTarget` | Meta | Live distance to the traced target; compared against `EffectiveRange`.
+| `EffectiveDamage` | Meta | Output of the hit-resolution calc after hitzone and falloff; for telemetry.
+|===
+
+[[genre-gunplay-loop]]
+== The gunplay loop (the core shooter mechanic)
+
+A shooter lives or dies on *gun feel*, and in UGAS that feel is a small loop of abilities, each
+gated by tags and an ammo resource.
+
+=== Fire — cost-gated and rate-paced
+
+`GA_Fire` (`entities/ability_fire.yaml`) requires `Weapon.Equipped` and is blocked while
+`State.Reloading`. On activation it traces under the crosshair (`WaitTargetData`) and applies
+`GE_BallisticDamage` to the hit target. Two reusable effects make the cadence work:
+
+* *Cost* — `GE_FireCost` subtracts `1` from `Ammo`. Because an ability cannot activate if it cannot
+  pay its cost, this is exactly what stops the gun firing on an empty magazine — no explicit
+  ammo-check tag is needed.
+* *Cooldown* — `GE_FireCooldown` runs for latexmath:[1 / \text{FireRate}] seconds, pacing automatic
+  fire.
+
+Both are trivial (a flat resource cost and a cooldown tag); the pack references them by name rather
+than shipping a file for each, the same convention the Racing pack uses for its nitro cost/cooldown.
+
+=== Reload — a state plus a stateful transfer
+
+`GA_Reload` is blocked while already reloading. It applies `GE_Reloading` (which grants
+`State.Reloading`, blocking fire and aim), waits the reload window, then applies `GE_Reload`. The
+amount of ammo moved depends on the live `Ammo`, `MagazineSize`, and `ReserveAmmo`, so it cannot be
+a static modifier — `GE_Reload` runs a custom `Execution` (`ExecCalc_MagazineReload`) that tops the
+magazine up and decrements the reserve by the rounds loaded. The "only reload when not full and the
+reserve is non-empty" check is activation logic, since attribute comparisons can't be activation tags.
+
+=== Aim down sights — accuracy traded for mobility
+
+`GA_Aim` uses the same hold-then-`WaitInputRelease` shape as the platformer jump: it applies
+`GE_ADS` on press and removes it on release. `GE_ADS` tightens the bullet cone and slows movement,
+and grants `State.Aiming`.
+
+=== Accuracy aggregation across channels
+
+`Spread` is the showcase of the core `Channel` mechanism. Modifiers are *additive within* a channel
+and *multiplicative across* channels, so aiming and attachments compose cleanly:
+
+* `GE_ADS` puts a `Multiply` of `-0.75` in the `Aim` channel: latexmath:[1 - 0.75 = 0.25].
+* `GE_AttachmentBarrel` puts a `Multiply` of `-0.5` in the `Attachments` channel:
+  latexmath:[1 - 0.5 = 0.50].
+
+.Worked example (`entities/gameplay_controller.yaml`)
+A soldier aiming a rifle that has a barrel attachment fitted:
+
+* `Spread`: latexmath:[2.0 \times 0.25 \times 0.50 = 0.25] (base × `Aim` × `Attachments`)
+* `MoveSpeed`: latexmath:[600 \times (1 - 0.3) = 420] (the `Aim` channel)
+* `EffectiveRange`: latexmath:[50 + 30 = 80] (a flat `Add`)
+
+These are exactly the `CurrentValue` entries recorded for the example soldier.
+
+[[genre-hit-resolution]]
+== Hit resolution
+
+`GE_BallisticDamage` (`entities/effect_ballistic_damage.yaml`) is the payload `GA_Fire` applies to
+the hit target. Shooter damage is not a single subtraction: it couples the source's aggregated
+`WeaponDamage` with *range falloff* (`DistanceToTarget` vs `EffectiveRange`), the *hitzone
+multiplier* (× `HeadshotMultiplier` when the target is hit on `Hitzone.Head`), and *shield-before-
+health* absorption. That can't be a static modifier, so the effect delegates to a custom
+`Execution` (`ExecCalc_HitResolution`) that honors `Immunity.Ballistic` targets and writes
+`EffectiveDamage` (a `Meta` attribute) for telemetry and UI. This is the shooter analogue of the
+Racing pack's traction calculator — the seam where a genre's signature math plugs into UGAS.
+
+[[genre-tags]]
+== Genre Tags
+
+Defined in `entities/tag_registry.yaml` (additive only):
+
+* *Weapon-handling states* — `State.Aiming`, `State.Reloading`, `State.Sprinting`.
+* *Weapon loadout* — `Weapon.Equipped`, `Weapon.Type.Rifle|Pistol|Shotgun|Sniper`,
+  `Weapon.FireMode.Auto|SemiAuto|Burst`, `Weapon.Attachment.Barrel`.
+* *Ability types* — `Ability.Type.Fire|Reload|Aim|Movement`.
+* *Damage & hitzones* — `DamageType.Ballistic|Explosive`, `Hitzone.Head|Body|Limb`.
+* *Teams & immunity* — `Team.Friendly|Hostile`, `Immunity.Ballistic`.
+
+[[genre-abilities]]
+== Genre Abilities
+
+* `entities/ability_fire.yaml` — `GA_Fire`: traces under the crosshair and applies
+  `GE_BallisticDamage`; costs `Ammo` and is paced by a per-shot cooldown.
+* `entities/ability_reload.yaml` — `GA_Reload`: applies `GE_Reloading`, waits, then runs the
+  `GE_Reload` magazine transfer.
+* `entities/ability_aim.yaml` — `GA_Aim`: holds `GE_ADS` for a tighter cone at the cost of movement.
+
+[[genre-effects]]
+== Genre Effects
+
+* `entities/effect_equip_rifle.yaml` — `GE_EquipRifle`: infinite; grants the weapon-loadout tags.
+* `entities/effect_ads.yaml` — `GE_ADS`: infinite-while-held; `Spread` and `MoveSpeed` multipliers
+  in the `Aim` channel; grants `State.Aiming`.
+* `entities/effect_attachment_barrel.yaml` — `GE_AttachmentBarrel`: infinite; `Spread` multiplier in
+  the `Attachments` channel and `+30` `EffectiveRange`; grants `Weapon.Attachment.Barrel`.
+* `entities/effect_reloading.yaml` — `GE_Reloading`: `HasDuration`; grants `State.Reloading`.
+* `entities/effect_reload.yaml` — `GE_Reload`: instant; `ExecCalc_MagazineReload` transfers reserve
+  rounds into the magazine.
+* `entities/effect_ballistic_damage.yaml` — `GE_BallisticDamage`: instant; `ExecCalc_HitResolution`
+  applies shields, hitzone multiplier, and falloff.
+
+[[using-this-pack]]
+== Using this pack
+
+. Copy `genres/shooter/` into your project (or load `entities/` directly via the
+  `ugas-schema-author` skill).
+. Tune the rifle base values in `ShooterCombatSet` first — they carry most of the gun feel — then
+  add new weapons as `GE_Equip*` effects and new attachments as `Attachments`-channel effects.
+. Implement the two `ExecCalc_*` hooks (`ExecCalc_MagazineReload`, `ExecCalc_HitResolution`) in your
+  engine; everything else is data.
+. Add new states as `State.*` tags granted by Effects (never mutate tags directly), and new weapons
+  /abilities as Effects + Abilities.
+. Validate with `python scripts/validate_schema_examples.py` before committing.


### PR DESCRIPTION
## Summary

Adds the **Shooter** genre pack (#33) — an additive, copy-and-extend FPS/TPS template on top of the core UGAS spec. There is no shooter case study in the core spec, so this pack is designed from first principles, grounded in standard gunplay mechanics, and reuses only core constructs (modifier `Channel`s, custom `Executions`, effect-granted tags).

- **`ShooterCombatSet`** — regenerating shield-then-health survivability, weapon-handling feel stats (`WeaponDamage`, `FireRate`, `Spread`, `HeadshotMultiplier`, `EffectiveRange`), and a magazine + reserve ammo economy. Base values describe a default rifle, so the set is playable as shipped.
- **Gunplay loop** — `GA_Fire` (trace + damage; cost-gated by `Ammo` so an empty magazine can't fire; paced by a `1/FireRate` cooldown), `GA_Reload` (reloading state → wait → stateful magazine transfer), `GA_Aim` (hold-to-ADS).
- **Two-channel accuracy aggregation** — the signature mechanic: `Spread = 2.0 × Aim(0.25) × Attachments(0.5) = 0.25`, mirroring the Racing pack's traction example; worked out in the example controller.
- **Two `ExecCalc_*` seams** — `ExecCalc_MagazineReload` and `ExecCalc_HitResolution` (shields, headshot multiplier, range falloff) as the engine hooks.
- Indexed in `genres/README.md` and `genres/index.adoc`; changeset `'ugas': minor`.

## Test plan

- [x] `python scripts/validate_schema_examples.py` passes (51 snippets; +12 from this pack)
- [x] `asciidoctor --failure-level=WARN genres/shooter/spec.adoc` builds with no warnings
- [x] `asciidoctor --failure-level=WARN genres/index.adoc` (updated landing page) builds clean
- [x] CI `validate-schema-examples` green
- [x] CI `preview-docs` renders `genres/shooter/index.html` and lists it on the packs index