### PR TITLE
ci: author the Version release PR with a GitHub App token

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -17,10 +17,21 @@ jobs:
   version:
     runs-on: ubuntu-latest
     steps:
+      # Mint a GitHub App installation token so the Version PR (and its branch
+      # push) is authored by the App, not GITHUB_TOKEN. Events from GITHUB_TOKEN
+      # don't trigger other workflows, which is why the release PR's CI never ran.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -43,4 +54,4 @@ jobs:
           title: "chore: release"
           commit: "chore: version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- The changesets **Version** PR was created with the default `GITHUB_TOKEN`. Events authored by `GITHUB_TOKEN` don't trigger other workflows (GitHub's anti-recursion rule), so the release PR's CI (`validate-schema-examples`, `preview-docs`) never ran.
- `version.yml` now mints a **GitHub App installation token** (`actions/create-github-app-token@v2`) and uses it for both `actions/checkout` and `changesets/action`, so the Version PR and its branch push are authored by the App and fire CI normally.

## Required setup (before this takes effect)
A GitHub App + two repo secrets are needed, or the `version` job will fail:
1. Create a GitHub App with **Contents: Read & write** and **Pull requests: Read & write**, installed on this repo.
2. Add repo secrets **`RELEASE_APP_ID`** and **`RELEASE_APP_PRIVATE_KEY`** (the App ID and the generated private key `.pem`).

## Notes
- CI-infra only — no change to the published `ugas` package, so no changeset.

## Test plan
- [x] After secrets are added, push a changeset to `develop` and confirm the Version PR opens **and** its `validate-schema-examples` / `preview-docs` checks run.