### PR TITLE
feat: formalize the input layer (Action, ActionSet, Mapping, Modifier)

### DIFF
--- a/.changeset/warm-inputs-land.md
+++ b/.changeset/warm-inputs-land.md
@@ -1,0 +1,5 @@
+---
+'ugas': minor
+---
+
+[Added] Input layer schemas (`input_action`, `input_action_set`, `input_mapping`, `input_modifier`) formalizing the pipeline from hardware device inputs through modifier processing to semantic actions and tag-driven action sets — with schema examples, genre templates, input entity files for all four genre packs (shooter, action, racing, RPG), an `ActiveActionSets` field on the Gameplay Controller, and a full rewrite of spec section 11 (#52).

--- a/genres/_template/entities/input_action.yaml
+++ b/genres/_template/entities/input_action.yaml
@@ -1,0 +1,14 @@
+# Template entity: Input Action
+# Replace with a genre-specific action definition.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: ExampleAction
+ValueType: Digital
+TriggerBehavior: OnPressed
+Tags:
+  ActionTags:
+    - Input.Type.Example
+Metadata:
+  DisplayName: Example Action
+  Description: Replace with a genre-specific input action
+  Category: General

--- a/genres/_template/entities/input_action_set.yaml
+++ b/genres/_template/entities/input_action_set.yaml
@@ -1,0 +1,14 @@
+# Template entity: Input Action Set
+# Replace with a genre-specific action set.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action_set.json
+Name: ExampleSet
+Actions:
+  - ExampleAction
+Priority: 0
+ActivationTags:
+  RequiredTags:
+    - State.Alive
+Metadata:
+  DisplayName: Example Set
+  Description: Replace with a genre-specific action set

--- a/genres/_template/entities/input_mapping.yaml
+++ b/genres/_template/entities/input_mapping.yaml
@@ -1,0 +1,13 @@
+# Template entity: Input Mapping
+# Replace with genre-specific bindings.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_mapping.json
+ActionSet: ExampleSet
+Bindings:
+  - Action: ExampleAction
+    Inputs:
+      - Device: Keyboard
+        Input: Key.Space
+Metadata:
+  DisplayName: Example Mapping
+  Description: Replace with genre-specific input bindings

--- a/genres/_template/entities/input_modifier.yaml
+++ b/genres/_template/entities/input_modifier.yaml
@@ -1,0 +1,13 @@
+# Template entity: Input Modifier
+# Replace with genre-specific modifier configuration.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_modifier.json
+Name: ExampleDeadzone
+Type: DeadZone
+Params:
+  InnerThreshold: 0.15
+  OuterThreshold: 0.95
+  DeadZoneShape: Radial
+Metadata:
+  DisplayName: Example Dead Zone
+  Description: Replace with a genre-specific modifier

--- a/genres/action/entities/input_action_set_onfoot.yaml
+++ b/genres/action/entities/input_action_set_onfoot.yaml
@@ -1,0 +1,22 @@
+# On-foot action set: the default action set for a platformer character.
+# Bundles all traversal and combat inputs available while the character is alive.
+# Input buffering is enabled with a generous 0.15 s window and depth of 3, which
+# smooths out rapid jump-chains and coyote-time sequences typical of the genre.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action_set.json
+Name: OnFoot
+Actions:
+  - Move
+  - Jump
+  - GroundPound
+Priority: 0
+ActivationTags:
+  RequiredTags:
+    - State.Alive
+InputBuffer:
+  Enabled: true
+  BufferWindow: 0.15
+  MaxBufferSize: 3
+Metadata:
+  DisplayName: On Foot
+  Description: Default movement and combat inputs for a grounded or airborne platformer hero

--- a/genres/action/entities/input_actions.yaml
+++ b/genres/action/entities/input_actions.yaml
@@ -1,0 +1,48 @@
+# Input actions for the action / platformer genre pack.
+# Move is a continuous 2D axis (WhileHeld) for analog stick and WASD movement.
+# Jump is digital OnPressed; the ability itself (GA_Jump) uses a WaitInputRelease task
+# to implement variable jump height, so the action only needs to fire the initial trigger.
+# GroundPound is digital OnPressed; the gameplay controller gates it to State.InAir via
+# the binding's RequiredTags, not the action definition.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Move
+ValueType: Axis2D
+TriggerBehavior: WhileHeld
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Movement
+Metadata:
+  DisplayName: Move
+  Description: Horizontal movement along the ground or in the air
+  Category: Movement
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Jump
+ValueType: Digital
+TriggerBehavior: OnPressed
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Movement
+Metadata:
+  DisplayName: Jump
+  Description: Leap upward; hold for a higher arc, release early to cut short
+  Icon: ui/icons/jump.png
+  Category: Movement
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: GroundPound
+ValueType: Digital
+TriggerBehavior: OnPressed
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Attack
+    - Ability.Type.Movement
+Metadata:
+  DisplayName: Ground Pound
+  Description: Slam downward while airborne, dealing damage on impact
+  Icon: ui/icons/ground_pound.png
+  Category: Movement

--- a/genres/action/entities/input_mapping_onfoot_gamepad.yaml
+++ b/genres/action/entities/input_mapping_onfoot_gamepad.yaml
@@ -1,0 +1,31 @@
+# Gamepad bindings for the OnFoot action set (Console platform).
+# Move uses the left stick with a radial dead-zone modifier for clean directional input.
+# Jump is mapped to FaceBottom (A / Cross) and GroundPound to LeftTrigger; the trigger
+# binding is gated behind State.InAir so it only fires while airborne.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_mapping.json
+ActionSet: OnFoot
+Platform: Console
+Bindings:
+  - Action: Move
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.LeftStick.X
+      - Device: Gamepad
+        Input: Gamepad.LeftStick.Y
+    Modifiers:
+      - StickDeadzone
+  - Action: Jump
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.FaceBottom
+  - Action: GroundPound
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.LeftTrigger
+    Tags:
+      RequiredTags:
+        - State.InAir
+Metadata:
+  DisplayName: On Foot (Gamepad)
+  Description: Standard console gamepad layout for platformer on-foot controls

--- a/genres/action/entities/input_mapping_onfoot_pc.yaml
+++ b/genres/action/entities/input_mapping_onfoot_pc.yaml
@@ -1,0 +1,37 @@
+# PC keyboard bindings for the OnFoot action set.
+# Move uses a WASD composite that the runtime promotes to an Axis2D vector.
+# Jump maps to Space; GroundPound maps to S but is gated behind State.InAir so
+# it only activates when airborne (prevents conflict with the downward Move axis).
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_mapping.json
+ActionSet: OnFoot
+Platform: PC
+Bindings:
+  - Action: Move
+    CompositeInputs:
+      Up:
+        Device: Keyboard
+        Input: Key.W
+      Down:
+        Device: Keyboard
+        Input: Key.S
+      Left:
+        Device: Keyboard
+        Input: Key.A
+      Right:
+        Device: Keyboard
+        Input: Key.D
+  - Action: Jump
+    Inputs:
+      - Device: Keyboard
+        Input: Key.Space
+  - Action: GroundPound
+    Inputs:
+      - Device: Keyboard
+        Input: Key.S
+    Tags:
+      RequiredTags:
+        - State.InAir
+Metadata:
+  DisplayName: On Foot (Keyboard)
+  Description: WASD + Space keyboard layout for the platformer on-foot controls

--- a/genres/action/entities/input_modifiers.yaml
+++ b/genres/action/entities/input_modifiers.yaml
@@ -1,0 +1,16 @@
+# Input modifiers for the action / platformer genre pack.
+# StickDeadzone applies a radial dead-zone to analog stick input, filtering out
+# drift near the center (Inner 0.15) and snapping to full deflection near the edge
+# (Outer 0.95). Marked UserConfigurable so players can tune thresholds in settings.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_modifier.json
+Name: StickDeadzone
+Type: DeadZone
+Params:
+  DeadZoneShape: Radial
+  InnerThreshold: 0.15
+  OuterThreshold: 0.95
+UserConfigurable: true
+Metadata:
+  DisplayName: Stick Dead Zone
+  Description: Radial dead-zone for analog sticks; filters center drift and snaps near full deflection

--- a/genres/racing/entities/input_action_set_racing.yaml
+++ b/genres/racing/entities/input_action_set_racing.yaml
@@ -1,0 +1,22 @@
+# Racing action set: groups all on-track driving inputs.
+# Active only while the vehicle is racing and not spun out.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action_set.json
+Name: RacingOnTrack
+Actions:
+  - Steer
+  - Throttle
+  - Brake
+  - Boost
+  - Drift
+  - Look
+Priority: 0
+ActivationTags:
+  RequiredTags:
+    - Vehicle
+    - Race.Phase.Racing
+  BlockedTags:
+    - Vehicle.State.SpunOut
+Metadata:
+  DisplayName: Racing
+  Description: Core driving input set active during on-track racing

--- a/genres/racing/entities/input_actions.yaml
+++ b/genres/racing/entities/input_actions.yaml
@@ -1,0 +1,75 @@
+# Input actions for the racing genre pack.
+# Steer, Throttle, Brake are analog axes; Boost and Drift are digital triggers;
+# Look provides a free-look camera axis while driving.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Steer
+ValueType: Axis1D
+TriggerBehavior: WhileHeld
+Tags:
+  ActionTags:
+    - Driving
+Metadata:
+  DisplayName: Steer
+  Description: Horizontal steering axis (-1 full left, +1 full right)
+  Category: Driving
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Throttle
+ValueType: Axis1D
+TriggerBehavior: WhileHeld
+Tags:
+  ActionTags:
+    - Driving
+Metadata:
+  DisplayName: Throttle
+  Description: Analog throttle input (0 idle, 1 full power)
+  Category: Driving
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Brake
+ValueType: Axis1D
+TriggerBehavior: WhileHeld
+Tags:
+  ActionTags:
+    - Driving
+Metadata:
+  DisplayName: Brake
+  Description: Analog brake input (0 no braking, 1 full braking)
+  Category: Driving
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Boost
+ValueType: Digital
+TriggerBehavior: OnPressed
+Tags:
+  ActionTags:
+    - Driving
+Metadata:
+  DisplayName: Boost
+  Description: Activate nitro boost
+  Category: Driving
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Drift
+ValueType: Digital
+TriggerBehavior: WhileHeld
+Tags:
+  ActionTags:
+    - Driving
+Metadata:
+  DisplayName: Drift
+  Description: Hold to initiate and sustain a drift through corners
+  Category: Driving
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Look
+ValueType: Axis2D
+TriggerBehavior: WhileHeld
+Tags:
+  ActionTags:
+    - Driving
+Metadata:
+  DisplayName: Look
+  Description: Free-look camera axis for glancing around while driving
+  Category: Driving

--- a/genres/racing/entities/input_mapping_racing_gamepad.yaml
+++ b/genres/racing/entities/input_mapping_racing_gamepad.yaml
@@ -1,0 +1,43 @@
+# Gamepad bindings for the RacingOnTrack action set (Console platform).
+# Maps standard gamepad controls to driving actions with appropriate modifiers.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_mapping.json
+ActionSet: RacingOnTrack
+Platform: Console
+Bindings:
+  - Action: Throttle
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.RightTrigger
+    Modifiers:
+      - TriggerDeadzone
+  - Action: Brake
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.LeftTrigger
+    Modifiers:
+      - TriggerDeadzone
+  - Action: Steer
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.LeftStick.X
+    Modifiers:
+      - StickDeadzone
+      - SteeringSensitivity
+  - Action: Boost
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.FaceBottom
+  - Action: Drift
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.LeftShoulder
+  - Action: Look
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.RightStick
+    Modifiers:
+      - StickDeadzone
+Metadata:
+  DisplayName: Racing Gamepad
+  Description: Default gamepad mapping for on-track racing controls

--- a/genres/racing/entities/input_modifiers.yaml
+++ b/genres/racing/entities/input_modifiers.yaml
@@ -1,0 +1,37 @@
+# Input modifiers shared by racing input mappings.
+# StickDeadzone and TriggerDeadzone clean up analog noise;
+# SteeringSensitivity applies an S-curve for progressive steering feel.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_modifier.json
+Name: StickDeadzone
+Type: DeadZone
+Params:
+  DeadZoneShape: Radial
+  InnerThreshold: 0.15
+  OuterThreshold: 0.95
+UserConfigurable: true
+Metadata:
+  DisplayName: Stick Dead Zone
+  Description: Radial dead zone for analog stick inputs
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_modifier.json
+Name: TriggerDeadzone
+Type: DeadZone
+Params:
+  DeadZoneShape: Axial
+  InnerThreshold: 0.05
+  OuterThreshold: 0.98
+UserConfigurable: false
+Metadata:
+  DisplayName: Trigger Dead Zone
+  Description: Axial dead zone for trigger inputs
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_modifier.json
+Name: SteeringSensitivity
+Type: ResponseCurve
+Params:
+  CurveType: SCurve
+UserConfigurable: true
+Metadata:
+  DisplayName: Steering Sensitivity
+  Description: S-curve response for progressive steering feel

--- a/genres/rpg/entities/input_action_set_onfoot.yaml
+++ b/genres/rpg/entities/input_action_set_onfoot.yaml
@@ -1,0 +1,16 @@
+# RPG on-foot action set. Active while the character is alive.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action_set.json
+Name: OnFoot
+Actions:
+  - BasicAttack
+  - Ability1
+  - Move
+  - Look
+Priority: 0
+ActivationTags:
+  RequiredTags:
+    - State.Alive
+Metadata:
+  DisplayName: On Foot
+  Description: Standard RPG controls for exploration and combat

--- a/genres/rpg/entities/input_actions.yaml
+++ b/genres/rpg/entities/input_actions.yaml
@@ -1,0 +1,55 @@
+# Input actions for the RPG genre pack.
+# BasicAttack is the primary left-click attack. Ability1 is the first hotbar slot.
+# Move and Look are standard 2D axes for character movement and camera control.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: BasicAttack
+ValueType: Digital
+TriggerBehavior: OnPressed
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Attack
+Metadata:
+  DisplayName: Basic Attack
+  Description: Primary melee or ranged attack
+  Category: Combat
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Ability1
+ValueType: Digital
+TriggerBehavior: OnPressed
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Active
+Metadata:
+  DisplayName: Ability 1
+  Description: First ability hotbar slot
+  Category: Combat
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Move
+ValueType: Axis2D
+TriggerBehavior: WhileHeld
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Movement
+Metadata:
+  DisplayName: Move
+  Description: Directional movement vector
+  Category: Movement
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Look
+ValueType: Axis2D
+TriggerBehavior: WhileHeld
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Movement
+Metadata:
+  DisplayName: Look
+  Description: Camera orientation
+  Category: Movement

--- a/genres/rpg/entities/input_mapping_onfoot_pc.yaml
+++ b/genres/rpg/entities/input_mapping_onfoot_pc.yaml
@@ -1,0 +1,42 @@
+# RPG PC keyboard+mouse bindings for on-foot gameplay.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_mapping.json
+ActionSet: OnFoot
+Platform: PC
+Bindings:
+  - Action: BasicAttack
+    Inputs:
+      - Device: Mouse
+        Input: Mouse.LeftButton
+
+  - Action: Ability1
+    Inputs:
+      - Device: Keyboard
+        Input: Key.1
+
+  - Action: Move
+    CompositeInputs:
+      Up:
+        Device: Keyboard
+        Input: Key.W
+      Down:
+        Device: Keyboard
+        Input: Key.S
+      Left:
+        Device: Keyboard
+        Input: Key.A
+      Right:
+        Device: Keyboard
+        Input: Key.D
+
+  - Action: Look
+    Inputs:
+      - Device: Mouse
+        Input: Mouse.Axis.X
+      - Device: Mouse
+        Input: Mouse.Axis.Y
+    Modifiers:
+      - MouseSensitivity
+Metadata:
+  DisplayName: On Foot (Keyboard + Mouse)
+  Description: Default PC bindings for RPG exploration and combat

--- a/genres/rpg/entities/input_modifiers.yaml
+++ b/genres/rpg/entities/input_modifiers.yaml
@@ -1,0 +1,13 @@
+# Reusable input modifiers for the RPG genre pack.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_modifier.json
+Name: MouseSensitivity
+Type: Sensitivity
+Params:
+  Multiplier: 1.0
+  MultiplierX: 1.0
+  MultiplierY: 1.0
+UserConfigurable: true
+Metadata:
+  DisplayName: Mouse Sensitivity
+  Description: Overall mouse look sensitivity

--- a/genres/shooter/entities/input_action_set_onfoot.yaml
+++ b/genres/shooter/entities/input_action_set_onfoot.yaml
@@ -1,0 +1,33 @@
+# On-Foot action set: the default input context for a shooter character on the ground.
+# Groups all nine actions (combat, movement, general) into a single set that is active
+# whenever the player is alive and not inside a vehicle or cutscene. Input buffering is
+# enabled with a tight 0.12 s window (max 2 queued events) so that rapid fire/reload
+# sequences feel responsive without swallowing unintended repeats.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action_set.json
+Name: OnFoot
+Actions:
+  - Fire
+  - Aim
+  - Reload
+  - Move
+  - Look
+  - Jump
+  - Sprint
+  - Interact
+  - CycleWeapon
+Priority: 0
+ActivationTags:
+  RequiredTags:
+    - State.Alive
+  BlockedTags:
+    - State.InVehicle
+    - State.Cutscene
+Exclusive: false
+InputBuffer:
+  Enabled: true
+  BufferWindow: 0.12
+  MaxBufferSize: 2
+Metadata:
+  DisplayName: On Foot
+  Description: Default on-foot input context covering combat, movement, and general interactions

--- a/genres/shooter/entities/input_actions.yaml
+++ b/genres/shooter/entities/input_actions.yaml
@@ -1,0 +1,139 @@
+# Shooter genre input actions. Each document defines a single action that an ability or
+# movement system can listen for. Actions are grouped into Action Sets (see
+# input_action_set_onfoot.yaml) and bound to hardware in Input Mappings.
+# Digital actions produce trigger events; Axis2D actions produce a continuous 2D vector.
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Fire
+ValueType: Digital
+TriggerBehavior: OnPressed
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Fire
+    - DamageType.Ballistic
+Metadata:
+  DisplayName: Fire
+  Description: Primary fire - pull the trigger
+  Icon: ui/icons/fire.png
+  Category: Combat
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Aim
+ValueType: Digital
+TriggerBehavior: WhileHeld
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Aim
+Metadata:
+  DisplayName: Aim Down Sights
+  Description: Hold to aim down sights for reduced spread and slower movement
+  Icon: ui/icons/aim.png
+  Category: Combat
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Reload
+ValueType: Digital
+TriggerBehavior: OnPressed
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Reload
+Metadata:
+  DisplayName: Reload
+  Description: Reload the currently equipped weapon
+  Icon: ui/icons/reload.png
+  Category: Combat
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Move
+ValueType: Axis2D
+TriggerBehavior: WhileHeld
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Movement
+Metadata:
+  DisplayName: Move
+  Description: Omnidirectional ground movement
+  Icon: ui/icons/move.png
+  Category: Movement
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Look
+ValueType: Axis2D
+TriggerBehavior: WhileHeld
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Movement
+Metadata:
+  DisplayName: Look
+  Description: Camera / aim direction
+  Icon: ui/icons/look.png
+  Category: Movement
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Jump
+ValueType: Digital
+TriggerBehavior: OnPressed
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Movement
+Metadata:
+  DisplayName: Jump
+  Description: Jump or vault over obstacles
+  Icon: ui/icons/jump.png
+  Category: Movement
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Sprint
+ValueType: Digital
+TriggerBehavior: WhileHeld
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Movement
+Metadata:
+  DisplayName: Sprint
+  Description: Hold to sprint at increased speed
+  Icon: ui/icons/sprint.png
+  Category: Movement
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Interact
+ValueType: Digital
+TriggerBehavior: OnPressed
+ConsumeInput: true
+Tags:
+  ActionTags: []
+Metadata:
+  DisplayName: Interact
+  Description: Context-sensitive interaction (doors, pickups, objectives)
+  Icon: ui/icons/interact.png
+  Category: General
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: CycleWeapon
+ValueType: Digital
+TriggerBehavior: OnPressed
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Fire
+Metadata:
+  DisplayName: Cycle Weapon
+  Description: Switch to the next weapon in the loadout
+  Icon: ui/icons/cycle_weapon.png
+  Category: Combat

--- a/genres/shooter/entities/input_mapping_onfoot_gamepad.yaml
+++ b/genres/shooter/entities/input_mapping_onfoot_gamepad.yaml
@@ -1,0 +1,70 @@
+# Console gamepad mapping for the OnFoot action set.
+# Analog triggers use a TriggerThreshold modifier so partial pulls are ignored below 0.5.
+# Both sticks pass through a radial dead zone; the right stick additionally gets an
+# AimAssistCurve (exponential response) for smoother aim control on a gamepad.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_mapping.json
+ActionSet: OnFoot
+Platform: Console
+Bindings:
+  - Action: Fire
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.RightTrigger
+    Modifiers:
+      - TriggerThreshold
+
+  - Action: Aim
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.LeftTrigger
+    Modifiers:
+      - TriggerThreshold
+
+  - Action: Reload
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.FaceLeft
+
+  - Action: Move
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.LeftStick.X
+      - Device: Gamepad
+        Input: Gamepad.LeftStick.Y
+    Modifiers:
+      - StickDeadzone
+      - RadialScaling
+
+  - Action: Look
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.RightStick.X
+      - Device: Gamepad
+        Input: Gamepad.RightStick.Y
+    Modifiers:
+      - StickDeadzone
+      - AimAssistCurve
+
+  - Action: Jump
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.FaceBottom
+
+  - Action: Sprint
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.LeftStickPress
+
+  - Action: Interact
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.FaceTop
+
+  - Action: CycleWeapon
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.DPad.Right
+Metadata:
+  DisplayName: On Foot - Gamepad
+  Description: Console gamepad bindings for the on-foot action set with aim assist and dead zones

--- a/genres/shooter/entities/input_mapping_onfoot_pc.yaml
+++ b/genres/shooter/entities/input_mapping_onfoot_pc.yaml
@@ -1,0 +1,69 @@
+# PC keyboard + mouse mapping for the OnFoot action set.
+# Move uses a WASD composite; Look uses raw mouse axes with a MouseSensitivity modifier
+# so the player can tune X/Y sensitivity independently in the settings screen.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_mapping.json
+ActionSet: OnFoot
+Platform: PC
+Bindings:
+  - Action: Fire
+    Inputs:
+      - Device: Mouse
+        Input: Mouse.LeftButton
+
+  - Action: Aim
+    Inputs:
+      - Device: Mouse
+        Input: Mouse.RightButton
+
+  - Action: Reload
+    Inputs:
+      - Device: Keyboard
+        Input: Key.R
+
+  - Action: Move
+    CompositeInputs:
+      Up:
+        Device: Keyboard
+        Input: Key.W
+      Down:
+        Device: Keyboard
+        Input: Key.S
+      Left:
+        Device: Keyboard
+        Input: Key.A
+      Right:
+        Device: Keyboard
+        Input: Key.D
+
+  - Action: Look
+    Inputs:
+      - Device: Mouse
+        Input: Mouse.Axis.X
+      - Device: Mouse
+        Input: Mouse.Axis.Y
+    Modifiers:
+      - MouseSensitivity
+
+  - Action: Jump
+    Inputs:
+      - Device: Keyboard
+        Input: Key.Space
+
+  - Action: Sprint
+    Inputs:
+      - Device: Keyboard
+        Input: Key.LeftShift
+
+  - Action: Interact
+    Inputs:
+      - Device: Keyboard
+        Input: Key.E
+
+  - Action: CycleWeapon
+    Inputs:
+      - Device: Mouse
+        Input: Mouse.Scroll
+Metadata:
+  DisplayName: On Foot - PC
+  Description: Keyboard and mouse bindings for the on-foot action set

--- a/genres/shooter/entities/input_modifiers.yaml
+++ b/genres/shooter/entities/input_modifiers.yaml
@@ -1,0 +1,64 @@
+# Reusable input modifiers for the shooter genre. Referenced by name in Input Mappings.
+# StickDeadzone and MouseSensitivity are player-configurable; the others are tuning knobs
+# owned by the designer. All modifiers sit in the per-binding modifier pipeline and run
+# in the order they are listed on each binding.
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_modifier.json
+Name: StickDeadzone
+Type: DeadZone
+Params:
+  DeadZoneShape: Radial
+  InnerThreshold: 0.15
+  OuterThreshold: 0.95
+UserConfigurable: true
+Metadata:
+  DisplayName: Stick Dead Zone
+  Description: Radial dead zone for analog sticks - ignores drift below 15% and saturates above 95%
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_modifier.json
+Name: MouseSensitivity
+Type: Sensitivity
+Params:
+  Multiplier: 1.0
+  MultiplierX: 1.0
+  MultiplierY: 1.0
+UserConfigurable: true
+Metadata:
+  DisplayName: Mouse Sensitivity
+  Description: Per-axis mouse sensitivity multiplier exposed in the player settings screen
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_modifier.json
+Name: TriggerThreshold
+Type: TriggerThreshold
+Params:
+  PressThreshold: 0.5
+UserConfigurable: false
+Metadata:
+  DisplayName: Trigger Threshold
+  Description: Analog trigger press threshold - values below 0.5 are treated as released
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_modifier.json
+Name: AimAssistCurve
+Type: ResponseCurve
+Params:
+  CurveType: Exponential
+  Exponent: 2.5
+UserConfigurable: false
+Metadata:
+  DisplayName: Aim Assist Curve
+  Description: Exponential response curve for gamepad aiming - slower near center, faster at extremes
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_modifier.json
+Name: RadialScaling
+Type: RadialScaling
+Params:
+  MaxRadius: 1.0
+UserConfigurable: false
+Metadata:
+  DisplayName: Radial Scaling
+  Description: Normalizes stick input to a maximum radius of 1.0 for consistent diagonal movement

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -12,6 +12,10 @@ This directory contains formal schema definitions for the Universal Gameplay Abi
 | **Gameplay Effect** | `gameplay_effect.json` | `gameplay_effect.yaml` | Schema for effects that modify attributes, grant tags/abilities, with duration and magnitude definitions |
 | **Gameplay Ability** | `gameplay_ability.json` | `gameplay_ability.yaml` | Schema for ability definitions with tag-based activation requirements and blocking rules |
 | **Gameplay Tag** | `gameplay_tag.json` | `gameplay_tag.yaml` | Schema for the tag registry defining semantic state labels in hierarchical notation |
+| **Input Action** | `input_action.json` | `input_action.yaml` | Schema for named semantic input intents with value types and trigger behaviors |
+| **Input Action Set** | `input_action_set.json` | `input_action_set.yaml` | Schema for context-based groups of actions with tag-driven activation |
+| **Input Mapping** | `input_mapping.json` | `input_mapping.yaml` | Schema for bindings between device inputs and actions, with chording, composition, and modifiers |
+| **Input Modifier** | `input_modifier.json` | `input_modifier.yaml` | Schema for reusable input signal processing steps (dead zones, sensitivity, response curves) |
 
 ## Schema Format
 
@@ -80,6 +84,104 @@ Metadata:
   DisplayName: Fireball
   Description: Launch a ball of fire at the target
   Icon: ui/icons/fireball.png
+```
+
+### Input Action Definition
+
+```yaml
+# fire_action.yaml
+Name: Fire
+ValueType: Digital
+TriggerBehavior: OnPressed
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Input.Type.Combat
+Metadata:
+  DisplayName: Fire Weapon
+  Description: Pull the trigger on the equipped weapon
+  Category: Combat
+```
+
+### Input Action Set Definition
+
+```yaml
+# onfoot_action_set.yaml
+Name: OnFoot
+Actions:
+  - Move
+  - Look
+  - Fire
+  - Aim
+  - Reload
+  - Jump
+  - Sprint
+Priority: 0
+ActivationTags:
+  RequiredTags:
+    - State.Alive
+  BlockedTags:
+    - State.InVehicle
+    - State.Cutscene
+InputBuffer:
+  Enabled: true
+  BufferWindow: 0.12
+  MaxBufferSize: 2
+Metadata:
+  DisplayName: On Foot
+```
+
+### Input Mapping Definition
+
+```yaml
+# onfoot_pc_mapping.yaml
+ActionSet: OnFoot
+Platform: PC
+Bindings:
+  - Action: Fire
+    Inputs:
+      - Device: Mouse
+        Input: Mouse.LeftButton
+
+  - Action: Move
+    CompositeInputs:
+      Up:
+        Device: Keyboard
+        Input: Key.W
+      Down:
+        Device: Keyboard
+        Input: Key.S
+      Left:
+        Device: Keyboard
+        Input: Key.A
+      Right:
+        Device: Keyboard
+        Input: Key.D
+
+  - Action: Look
+    Inputs:
+      - Device: Mouse
+        Input: Mouse.Axis.X
+      - Device: Mouse
+        Input: Mouse.Axis.Y
+    Modifiers:
+      - MouseSensitivity
+```
+
+### Input Modifier Definition
+
+```yaml
+# stick_deadzone_modifier.yaml
+Name: StickDeadzone
+Type: DeadZone
+Params:
+  InnerThreshold: 0.15
+  OuterThreshold: 0.95
+  DeadZoneShape: Radial
+UserConfigurable: true
+Metadata:
+  DisplayName: Stick Dead Zone
+  Description: Inner dead zone radius for analog sticks
 ```
 
 ### Gameplay Tag Registry
@@ -193,6 +295,7 @@ These schemas are based on the **Universal Gameplay Ability System Specification
 - **Section 7**: Gameplay Tags - `gameplay_tag.{json,yaml}`
 - **Section 8**: Gameplay Abilities - `gameplay_ability.{json,yaml}`
 - **Section 9**: Gameplay Effects - `gameplay_effect.{json,yaml}`
+- **Section 11**: Input Integration - `input_action.{json,yaml}`, `input_action_set.{json,yaml}`, `input_mapping.{json,yaml}`, `input_modifier.{json,yaml}`
 - **Appendix B**: Complete Schema Reference
 
 ## Notes

--- a/schemas/examples/fire_action.yaml
+++ b/schemas/examples/fire_action.yaml
@@ -1,0 +1,15 @@
+# Example: Fire Action (Shooter)
+# Demonstrates a digital combat action with press-to-activate trigger behavior
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Fire
+ValueType: Digital
+TriggerBehavior: OnPressed
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Input.Type.Combat
+Metadata:
+  DisplayName: Fire Weapon
+  Description: Pull the trigger on the equipped weapon
+  Category: Combat

--- a/schemas/examples/onfoot_action_set.yaml
+++ b/schemas/examples/onfoot_action_set.yaml
@@ -1,0 +1,29 @@
+# Example: OnFoot Action Set (Shooter)
+# Demonstrates tag-driven activation with input buffering
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action_set.json
+Name: OnFoot
+Actions:
+  - Move
+  - Look
+  - Fire
+  - Aim
+  - Reload
+  - Jump
+  - Sprint
+  - Interact
+  - CycleWeapon
+Priority: 0
+ActivationTags:
+  RequiredTags:
+    - State.Alive
+  BlockedTags:
+    - State.InVehicle
+    - State.Cutscene
+InputBuffer:
+  Enabled: true
+  BufferWindow: 0.12
+  MaxBufferSize: 2
+Metadata:
+  DisplayName: On Foot
+  Description: Standard FPS controls while on foot

--- a/schemas/examples/onfoot_pc_mapping.yaml
+++ b/schemas/examples/onfoot_pc_mapping.yaml
@@ -1,0 +1,68 @@
+# Example: OnFoot PC Mapping (Shooter)
+# Demonstrates keyboard+mouse bindings with WASD composition and modifier references
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_mapping.json
+ActionSet: OnFoot
+Platform: PC
+Bindings:
+  - Action: Fire
+    Inputs:
+      - Device: Mouse
+        Input: Mouse.LeftButton
+
+  - Action: Aim
+    Inputs:
+      - Device: Mouse
+        Input: Mouse.RightButton
+
+  - Action: Reload
+    Inputs:
+      - Device: Keyboard
+        Input: Key.R
+
+  - Action: Move
+    CompositeInputs:
+      Up:
+        Device: Keyboard
+        Input: Key.W
+      Down:
+        Device: Keyboard
+        Input: Key.S
+      Left:
+        Device: Keyboard
+        Input: Key.A
+      Right:
+        Device: Keyboard
+        Input: Key.D
+
+  - Action: Look
+    Inputs:
+      - Device: Mouse
+        Input: Mouse.Axis.X
+      - Device: Mouse
+        Input: Mouse.Axis.Y
+    Modifiers:
+      - MouseSensitivity
+
+  - Action: Jump
+    Inputs:
+      - Device: Keyboard
+        Input: Key.Space
+
+  - Action: Sprint
+    Inputs:
+      - Device: Keyboard
+        Input: Key.LeftShift
+
+  - Action: Interact
+    Inputs:
+      - Device: Keyboard
+        Input: Key.E
+
+  - Action: CycleWeapon
+    Inputs:
+      - Device: Mouse
+        Input: Mouse.Scroll
+Metadata:
+  DisplayName: On Foot (Keyboard + Mouse)
+  Description: Default PC bindings for on-foot shooter gameplay

--- a/schemas/examples/stick_deadzone_modifier.yaml
+++ b/schemas/examples/stick_deadzone_modifier.yaml
@@ -1,0 +1,14 @@
+# Example: Stick Deadzone Modifier
+# Demonstrates a user-configurable radial dead zone for gamepad analog sticks
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_modifier.json
+Name: StickDeadzone
+Type: DeadZone
+Params:
+  InnerThreshold: 0.15
+  OuterThreshold: 0.95
+  DeadZoneShape: Radial
+UserConfigurable: true
+Metadata:
+  DisplayName: Stick Dead Zone
+  Description: Inner dead zone radius for analog sticks

--- a/schemas/gameplay_controller.json
+++ b/schemas/gameplay_controller.json
@@ -83,7 +83,7 @@
           },
           "InputID": {
             "type": "string",
-            "description": "Optional input binding identifier"
+            "description": "Input binding identifier. References an Action Name from the input layer. When the bound Action triggers, the GC calls TryActivateAbility for this grant."
           },
           "Handle": {
             "type": "string",
@@ -138,6 +138,13 @@
         }
       },
       "description": "Currently active effects applied to this GC"
+    },
+    "ActiveActionSets": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Currently active ActionSet names (derived from tag evaluation at runtime)"
     },
     "OwnedTags": {
       "type": "array",

--- a/schemas/gameplay_controller.yaml
+++ b/schemas/gameplay_controller.yaml
@@ -67,7 +67,10 @@ properties:
           description: Ability level
         InputID:
           type: string
-          description: Optional input binding identifier
+          description: >-
+            Input binding identifier. References an Action Name from the input
+            layer. When the bound Action triggers, the GC calls TryActivateAbility
+            for this grant.
         Handle:
           type: string
           description: Unique handle for this granted ability instance
@@ -110,6 +113,12 @@ properties:
           type: string
           description: Reference to the GC that caused this effect
     description: Currently active effects applied to this GC
+
+  ActiveActionSets:
+    type: array
+    items:
+      type: string
+    description: Currently active ActionSet names (derived from tag evaluation at runtime)
 
   OwnedTags:
     type: array

--- a/schemas/input_action.json
+++ b/schemas/input_action.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/jbltx/ugas/schemas/input_action.json",
+  "title": "Input Action Definition Schema",
+  "description": "Based on UGAS Specification %%UGAS_VERSION%% - Section 11",
+  "type": "object",
+  "required": [
+    "Name",
+    "ValueType"
+  ],
+  "properties": {
+    "Name": {
+      "type": "string",
+      "description": "Unique identifier for this action, referenced by InputID on granted abilities"
+    },
+    "ValueType": {
+      "type": "string",
+      "enum": ["Digital", "Axis1D", "Axis2D", "Axis3D"],
+      "description": "Semantic value type this action produces. Digital actions emit trigger events (Started/Ongoing/Completed). Axis actions emit a continuous value each frame while nonzero."
+    },
+    "TriggerBehavior": {
+      "type": "string",
+      "enum": ["OnPressed", "OnReleased", "WhileHeld", "OnTap", "OnDoubleTap"],
+      "default": "OnPressed",
+      "description": "When this action fires its trigger event. OnPressed fires once on activation. WhileHeld fires every frame while input is nonzero. OnTap requires press-then-release within TapThreshold."
+    },
+    "TapThreshold": {
+      "type": "number",
+      "minimum": 0,
+      "default": 0.2,
+      "description": "Maximum hold duration (seconds) for OnTap and OnDoubleTap"
+    },
+    "DoubleTapWindow": {
+      "type": "number",
+      "minimum": 0,
+      "default": 0.3,
+      "description": "Maximum gap (seconds) between two taps for OnDoubleTap"
+    },
+    "ConsumeInput": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether this action consumes the input event, preventing lower-priority actions from receiving it"
+    },
+    "Tags": {
+      "type": "object",
+      "properties": {
+        "ActionTags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Tags describing this action for bulk queries (e.g. disable all combat inputs)"
+        }
+      }
+    },
+    "Metadata": {
+      "type": "object",
+      "properties": {
+        "DisplayName": {
+          "type": "string",
+          "description": "Localization-friendly name shown in control remapping UI"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Icon": {
+          "type": "string"
+        },
+        "Category": {
+          "type": "string",
+          "description": "UI grouping for settings screens (e.g. Movement, Combat)"
+        }
+      }
+    }
+  }
+}

--- a/schemas/input_action.yaml
+++ b/schemas/input_action.yaml
@@ -1,0 +1,70 @@
+# Input Action Definition Schema
+# Based on UGAS Specification %%UGAS_VERSION%% - Section 11
+
+type: object
+required:
+  - Name
+  - ValueType
+properties:
+  Name:
+    type: string
+    description: Unique identifier for this action, referenced by InputID on granted abilities
+  ValueType:
+    type: string
+    enum:
+      - Digital
+      - Axis1D
+      - Axis2D
+      - Axis3D
+    description: >-
+      Semantic value type this action produces. Digital actions emit trigger events
+      (Started/Ongoing/Completed). Axis actions emit a continuous value each frame
+      while nonzero.
+  TriggerBehavior:
+    type: string
+    enum:
+      - OnPressed
+      - OnReleased
+      - WhileHeld
+      - OnTap
+      - OnDoubleTap
+    default: OnPressed
+    description: >-
+      When this action fires its trigger event. OnPressed fires once on activation.
+      WhileHeld fires every frame while input is nonzero. OnTap requires
+      press-then-release within TapThreshold.
+  TapThreshold:
+    type: number
+    minimum: 0
+    default: 0.2
+    description: Maximum hold duration (seconds) for OnTap and OnDoubleTap
+  DoubleTapWindow:
+    type: number
+    minimum: 0
+    default: 0.3
+    description: Maximum gap (seconds) between two taps for OnDoubleTap
+  ConsumeInput:
+    type: boolean
+    default: true
+    description: Whether this action consumes the input event, preventing lower-priority actions from receiving it
+  Tags:
+    type: object
+    properties:
+      ActionTags:
+        type: array
+        items:
+          type: string
+        description: Tags describing this action for bulk queries (e.g. disable all combat inputs)
+  Metadata:
+    type: object
+    properties:
+      DisplayName:
+        type: string
+        description: Localization-friendly name shown in control remapping UI
+      Description:
+        type: string
+      Icon:
+        type: string
+      Category:
+        type: string
+        description: UI grouping for settings screens (e.g. Movement, Combat)

--- a/schemas/input_action_set.json
+++ b/schemas/input_action_set.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/jbltx/ugas/schemas/input_action_set.json",
+  "title": "Input Action Set Definition Schema",
+  "description": "Based on UGAS Specification %%UGAS_VERSION%% - Section 11",
+  "type": "object",
+  "required": [
+    "Name",
+    "Actions"
+  ],
+  "properties": {
+    "Name": {
+      "type": "string",
+      "description": "Unique identifier for this action set"
+    },
+    "Actions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Reference to an Action Name"
+      },
+      "minItems": 1,
+      "description": "Actions available when this set is active"
+    },
+    "Priority": {
+      "type": "integer",
+      "default": 0,
+      "description": "When multiple sets are active and contain the same Action, the highest priority wins. Enables layering (e.g. a Dialogue set overlays OnFoot)."
+    },
+    "ActivationTags": {
+      "type": "object",
+      "properties": {
+        "RequiredTags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Tags required on the owning GC for this set to be active (AND logic)"
+        },
+        "BlockedTags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Tags that deactivate this set if any are present on the GC"
+        }
+      }
+    },
+    "Exclusive": {
+      "type": "boolean",
+      "default": false,
+      "description": "If true, activating this set deactivates all other non-exclusive sets at the same or lower priority. Useful for modal contexts like vehicles or cutscenes."
+    },
+    "InputBuffer": {
+      "type": "object",
+      "description": "Per-set input buffering configuration, overrides the global InputBufferConfig",
+      "properties": {
+        "Enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "BufferWindow": {
+          "type": "number",
+          "minimum": 0,
+          "default": 0.15,
+          "description": "Buffer window in seconds"
+        },
+        "MaxBufferSize": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 3
+        }
+      }
+    },
+    "Metadata": {
+      "type": "object",
+      "properties": {
+        "DisplayName": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/schemas/input_action_set.yaml
+++ b/schemas/input_action_set.yaml
@@ -1,0 +1,66 @@
+# Input Action Set Definition Schema
+# Based on UGAS Specification %%UGAS_VERSION%% - Section 11
+
+type: object
+required:
+  - Name
+  - Actions
+properties:
+  Name:
+    type: string
+    description: Unique identifier for this action set
+  Actions:
+    type: array
+    items:
+      type: string
+      description: Reference to an Action Name
+    minItems: 1
+    description: Actions available when this set is active
+  Priority:
+    type: integer
+    default: 0
+    description: >-
+      When multiple sets are active and contain the same Action, the highest
+      priority wins. Enables layering (e.g. a Dialogue set overlays OnFoot).
+  ActivationTags:
+    type: object
+    properties:
+      RequiredTags:
+        type: array
+        items:
+          type: string
+        description: Tags required on the owning GC for this set to be active (AND logic)
+      BlockedTags:
+        type: array
+        items:
+          type: string
+        description: Tags that deactivate this set if any are present on the GC
+  Exclusive:
+    type: boolean
+    default: false
+    description: >-
+      If true, activating this set deactivates all other non-exclusive sets at
+      the same or lower priority. Useful for modal contexts like vehicles or cutscenes.
+  InputBuffer:
+    type: object
+    description: Per-set input buffering configuration, overrides the global InputBufferConfig
+    properties:
+      Enabled:
+        type: boolean
+        default: false
+      BufferWindow:
+        type: number
+        minimum: 0
+        default: 0.15
+        description: Buffer window in seconds
+      MaxBufferSize:
+        type: integer
+        minimum: 1
+        default: 3
+  Metadata:
+    type: object
+    properties:
+      DisplayName:
+        type: string
+      Description:
+        type: string

--- a/schemas/input_mapping.json
+++ b/schemas/input_mapping.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/jbltx/ugas/schemas/input_mapping.json",
+  "title": "Input Mapping Definition Schema",
+  "description": "Based on UGAS Specification %%UGAS_VERSION%% - Section 11",
+  "type": "object",
+  "required": [
+    "ActionSet",
+    "Bindings"
+  ],
+  "properties": {
+    "ActionSet": {
+      "type": "string",
+      "description": "The ActionSet this mapping belongs to"
+    },
+    "Platform": {
+      "type": "string",
+      "enum": ["PC", "Console", "Mobile", "VR"],
+      "description": "Optional platform filter. When set, these bindings only apply on the specified platform. Omit for universal bindings."
+    },
+    "Bindings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Binding"
+      },
+      "minItems": 1
+    },
+    "Metadata": {
+      "type": "object",
+      "properties": {
+        "DisplayName": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "DeviceInput": {
+      "type": "object",
+      "required": ["Device", "Input"],
+      "properties": {
+        "Device": {
+          "type": "string",
+          "enum": ["Keyboard", "Mouse", "Gamepad", "Touch", "Gyro", "Custom"],
+          "description": "Device family"
+        },
+        "Input": {
+          "type": "string",
+          "description": "Canonical input identifier within the device family, using a standardized naming convention independent of any engine (e.g. Key.Space, Mouse.LeftButton, Gamepad.FaceBottom)"
+        },
+        "CustomDeviceName": {
+          "type": "string",
+          "description": "When Device is Custom, the specific hardware identifier (e.g. FlightStick, SteeringWheel)"
+        }
+      }
+    },
+    "CompositeInputs": {
+      "type": "object",
+      "description": "Composes multiple digital inputs into an axis value. Used for WASD-to-2D-vector, arrow-keys-to-axis, etc.",
+      "properties": {
+        "Up": {
+          "$ref": "#/$defs/DeviceInput"
+        },
+        "Down": {
+          "$ref": "#/$defs/DeviceInput"
+        },
+        "Left": {
+          "$ref": "#/$defs/DeviceInput"
+        },
+        "Right": {
+          "$ref": "#/$defs/DeviceInput"
+        },
+        "Forward": {
+          "$ref": "#/$defs/DeviceInput"
+        },
+        "Backward": {
+          "$ref": "#/$defs/DeviceInput"
+        }
+      }
+    },
+    "Binding": {
+      "type": "object",
+      "required": ["Action"],
+      "properties": {
+        "Action": {
+          "type": "string",
+          "description": "Reference to an Action Name"
+        },
+        "Inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DeviceInput"
+          },
+          "minItems": 1,
+          "description": "Device input(s) for this binding. A single entry is a simple binding. Multiple entries create a chord (all must be active simultaneously)."
+        },
+        "CompositeInputs": {
+          "$ref": "#/$defs/CompositeInputs"
+        },
+        "Modifiers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Ordered list of Modifier references applied to the raw input value (pipeline order)"
+        },
+        "Priority": {
+          "type": "integer",
+          "default": 0,
+          "description": "When multiple bindings map to the same Action within the same ActionSet, the highest priority binding that is satisfiable wins."
+        },
+        "HoldThreshold": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Seconds the input must be held before the binding activates. Useful for distinguishing tap (interact) from hold (pick up)."
+        },
+        "bIsRebindable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether the player can change this binding in controls settings"
+        },
+        "Tags": {
+          "type": "object",
+          "properties": {
+            "RequiredTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Additional tag requirements beyond the ActionSet's ActivationTags"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/input_mapping.yaml
+++ b/schemas/input_mapping.yaml
@@ -1,0 +1,127 @@
+# Input Mapping Definition Schema
+# Based on UGAS Specification %%UGAS_VERSION%% - Section 11
+
+type: object
+required:
+  - ActionSet
+  - Bindings
+properties:
+  ActionSet:
+    type: string
+    description: The ActionSet this mapping belongs to
+  Platform:
+    type: string
+    enum:
+      - PC
+      - Console
+      - Mobile
+      - VR
+    description: >-
+      Optional platform filter. When set, these bindings only apply on the
+      specified platform. Omit for universal bindings.
+  Bindings:
+    type: array
+    items:
+      $ref: "#/$defs/Binding"
+    minItems: 1
+  Metadata:
+    type: object
+    properties:
+      DisplayName:
+        type: string
+      Description:
+        type: string
+
+$defs:
+  DeviceInput:
+    type: object
+    required:
+      - Device
+      - Input
+    properties:
+      Device:
+        type: string
+        enum:
+          - Keyboard
+          - Mouse
+          - Gamepad
+          - Touch
+          - Gyro
+          - Custom
+        description: Device family
+      Input:
+        type: string
+        description: >-
+          Canonical input identifier within the device family, using a
+          standardized naming convention independent of any engine
+          (e.g. Key.Space, Mouse.LeftButton, Gamepad.FaceBottom)
+      CustomDeviceName:
+        type: string
+        description: When Device is Custom, the specific hardware identifier (e.g. FlightStick, SteeringWheel)
+
+  CompositeInputs:
+    type: object
+    description: >-
+      Composes multiple digital inputs into an axis value.
+      Used for WASD-to-2D-vector, arrow-keys-to-axis, etc.
+    properties:
+      Up:
+        $ref: "#/$defs/DeviceInput"
+      Down:
+        $ref: "#/$defs/DeviceInput"
+      Left:
+        $ref: "#/$defs/DeviceInput"
+      Right:
+        $ref: "#/$defs/DeviceInput"
+      Forward:
+        $ref: "#/$defs/DeviceInput"
+      Backward:
+        $ref: "#/$defs/DeviceInput"
+
+  Binding:
+    type: object
+    required:
+      - Action
+    properties:
+      Action:
+        type: string
+        description: Reference to an Action Name
+      Inputs:
+        type: array
+        items:
+          $ref: "#/$defs/DeviceInput"
+        minItems: 1
+        description: >-
+          Device input(s) for this binding. A single entry is a simple binding.
+          Multiple entries create a chord (all must be active simultaneously).
+      CompositeInputs:
+        $ref: "#/$defs/CompositeInputs"
+      Modifiers:
+        type: array
+        items:
+          type: string
+        description: Ordered list of Modifier references applied to the raw input value (pipeline order)
+      Priority:
+        type: integer
+        default: 0
+        description: >-
+          When multiple bindings map to the same Action within the same
+          ActionSet, the highest priority binding that is satisfiable wins.
+      HoldThreshold:
+        type: number
+        minimum: 0
+        description: >-
+          Seconds the input must be held before the binding activates.
+          Useful for distinguishing tap (interact) from hold (pick up).
+      bIsRebindable:
+        type: boolean
+        default: true
+        description: Whether the player can change this binding in controls settings
+      Tags:
+        type: object
+        properties:
+          RequiredTags:
+            type: array
+            items:
+              type: string
+            description: Additional tag requirements beyond the ActionSet's ActivationTags

--- a/schemas/input_modifier.json
+++ b/schemas/input_modifier.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/jbltx/ugas/schemas/input_modifier.json",
+  "title": "Input Modifier Definition Schema",
+  "description": "Based on UGAS Specification %%UGAS_VERSION%% - Section 11",
+  "type": "object",
+  "required": [
+    "Name",
+    "Type"
+  ],
+  "properties": {
+    "Name": {
+      "type": "string",
+      "description": "Unique identifier for this modifier"
+    },
+    "Type": {
+      "type": "string",
+      "enum": [
+        "DeadZone",
+        "Sensitivity",
+        "ResponseCurve",
+        "AxisInvert",
+        "AxisScale",
+        "AxisSwizzle",
+        "RadialScaling",
+        "Normalize",
+        "TriggerThreshold",
+        "Clamp",
+        "Custom"
+      ],
+      "description": "The processing operation this modifier performs"
+    },
+    "Params": {
+      "type": "object",
+      "description": "Type-specific parameters",
+      "properties": {
+        "InnerThreshold": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "DeadZone: values below this threshold are clamped to zero"
+        },
+        "OuterThreshold": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "DeadZone: values above this threshold are clamped to 1.0"
+        },
+        "DeadZoneShape": {
+          "type": "string",
+          "enum": ["Axial", "Radial"],
+          "description": "DeadZone: Axial applies per-axis, Radial applies to magnitude of 2D vector"
+        },
+        "Multiplier": {
+          "type": "number",
+          "description": "Sensitivity: linear multiplier (1.0 = no change)"
+        },
+        "MultiplierX": {
+          "type": "number",
+          "description": "Sensitivity: per-axis X multiplier for 2D actions"
+        },
+        "MultiplierY": {
+          "type": "number",
+          "description": "Sensitivity: per-axis Y multiplier for 2D actions"
+        },
+        "CurveType": {
+          "type": "string",
+          "enum": ["Linear", "Exponential", "SCurve", "Custom"],
+          "description": "ResponseCurve: curve shape"
+        },
+        "Exponent": {
+          "type": "number",
+          "description": "ResponseCurve: exponent for Exponential curves (1.0 = linear, 2.0 = quadratic)"
+        },
+        "CurvePoints": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "In": {
+                "type": "number"
+              },
+              "Out": {
+                "type": "number"
+              }
+            }
+          },
+          "description": "ResponseCurve: explicit input-to-output mapping points for Custom curves"
+        },
+        "InvertX": {
+          "type": "boolean",
+          "default": false,
+          "description": "AxisInvert: invert horizontal axis"
+        },
+        "InvertY": {
+          "type": "boolean",
+          "default": false,
+          "description": "AxisInvert: invert vertical axis"
+        },
+        "ScaleX": {
+          "type": "number",
+          "description": "AxisScale: horizontal scale factor"
+        },
+        "ScaleY": {
+          "type": "number",
+          "description": "AxisScale: vertical scale factor"
+        },
+        "ScaleZ": {
+          "type": "number",
+          "description": "AxisScale: depth scale factor (for Axis3D)"
+        },
+        "SwizzleOrder": {
+          "type": "string",
+          "description": "AxisSwizzle: axis reordering (e.g. YXZ to swap X and Y)"
+        },
+        "MaxRadius": {
+          "type": "number",
+          "description": "RadialScaling: maximum radius for normalization"
+        },
+        "PressThreshold": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.5,
+          "description": "TriggerThreshold: analog value above which a trigger counts as pressed"
+        },
+        "Min": {
+          "type": "number",
+          "description": "Clamp: minimum value"
+        },
+        "Max": {
+          "type": "number",
+          "description": "Clamp: maximum value"
+        },
+        "CalculatorClass": {
+          "type": "string",
+          "description": "Custom: engine-specific class implementing the modifier logic"
+        }
+      }
+    },
+    "UserConfigurable": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether this modifier's params are exposed in the player's settings screen. When true, the runtime SHOULD present relevant params (e.g. sensitivity slider, invert-Y toggle) in the controls menu."
+    },
+    "Metadata": {
+      "type": "object",
+      "properties": {
+        "DisplayName": {
+          "type": "string",
+          "description": "Name shown in settings UI when UserConfigurable"
+        },
+        "Description": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/schemas/input_modifier.yaml
+++ b/schemas/input_modifier.yaml
@@ -1,0 +1,129 @@
+# Input Modifier Definition Schema
+# Based on UGAS Specification %%UGAS_VERSION%% - Section 11
+
+type: object
+required:
+  - Name
+  - Type
+properties:
+  Name:
+    type: string
+    description: Unique identifier for this modifier
+  Type:
+    type: string
+    enum:
+      - DeadZone
+      - Sensitivity
+      - ResponseCurve
+      - AxisInvert
+      - AxisScale
+      - AxisSwizzle
+      - RadialScaling
+      - Normalize
+      - TriggerThreshold
+      - Clamp
+      - Custom
+    description: The processing operation this modifier performs
+  Params:
+    type: object
+    description: Type-specific parameters
+    properties:
+      InnerThreshold:
+        type: number
+        minimum: 0
+        maximum: 1
+        description: "DeadZone: values below this threshold are clamped to zero"
+      OuterThreshold:
+        type: number
+        minimum: 0
+        maximum: 1
+        description: "DeadZone: values above this threshold are clamped to 1.0"
+      DeadZoneShape:
+        type: string
+        enum:
+          - Axial
+          - Radial
+        description: "DeadZone: Axial applies per-axis, Radial applies to magnitude of 2D vector"
+      Multiplier:
+        type: number
+        description: "Sensitivity: linear multiplier (1.0 = no change)"
+      MultiplierX:
+        type: number
+        description: "Sensitivity: per-axis X multiplier for 2D actions"
+      MultiplierY:
+        type: number
+        description: "Sensitivity: per-axis Y multiplier for 2D actions"
+      CurveType:
+        type: string
+        enum:
+          - Linear
+          - Exponential
+          - SCurve
+          - Custom
+        description: "ResponseCurve: curve shape"
+      Exponent:
+        type: number
+        description: "ResponseCurve: exponent for Exponential curves (1.0 = linear, 2.0 = quadratic)"
+      CurvePoints:
+        type: array
+        items:
+          type: object
+          properties:
+            In:
+              type: number
+            Out:
+              type: number
+        description: "ResponseCurve: explicit input-to-output mapping points for Custom curves"
+      InvertX:
+        type: boolean
+        default: false
+        description: "AxisInvert: invert horizontal axis"
+      InvertY:
+        type: boolean
+        default: false
+        description: "AxisInvert: invert vertical axis"
+      ScaleX:
+        type: number
+        description: "AxisScale: horizontal scale factor"
+      ScaleY:
+        type: number
+        description: "AxisScale: vertical scale factor"
+      ScaleZ:
+        type: number
+        description: "AxisScale: depth scale factor (for Axis3D)"
+      SwizzleOrder:
+        type: string
+        description: "AxisSwizzle: axis reordering (e.g. YXZ to swap X and Y)"
+      MaxRadius:
+        type: number
+        description: "RadialScaling: maximum radius for normalization"
+      PressThreshold:
+        type: number
+        minimum: 0
+        maximum: 1
+        default: 0.5
+        description: "TriggerThreshold: analog value above which a trigger counts as pressed"
+      Min:
+        type: number
+        description: "Clamp: minimum value"
+      Max:
+        type: number
+        description: "Clamp: maximum value"
+      CalculatorClass:
+        type: string
+        description: "Custom: engine-specific class implementing the modifier logic"
+  UserConfigurable:
+    type: boolean
+    default: false
+    description: >-
+      Whether this modifier's params are exposed in the player's settings screen.
+      When true, the runtime SHOULD present relevant params (e.g. sensitivity
+      slider, invert-Y toggle) in the controls menu.
+  Metadata:
+    type: object
+    properties:
+      DisplayName:
+        type: string
+        description: Name shown in settings UI when UserConfigurable
+      Description:
+        type: string

--- a/scripts/compare_schema_definitions.py
+++ b/scripts/compare_schema_definitions.py
@@ -20,6 +20,13 @@ SCHEMA_PAIRS: Dict[str, Tuple[str, str]] = {
         "schemas/gameplay_controller.json",
         "schemas/gameplay_controller.yaml",
     ),
+    "input_action": ("schemas/input_action.json", "schemas/input_action.yaml"),
+    "input_action_set": (
+        "schemas/input_action_set.json",
+        "schemas/input_action_set.yaml",
+    ),
+    "input_mapping": ("schemas/input_mapping.json", "schemas/input_mapping.yaml"),
+    "input_modifier": ("schemas/input_modifier.json", "schemas/input_modifier.yaml"),
 }
 
 ROOT_METADATA_KEYS = {"$schema", "$id", "title", "description"}

--- a/scripts/validate_schema_examples.py
+++ b/scripts/validate_schema_examples.py
@@ -20,6 +20,10 @@ SCHEMA_FILES = {
     "gameplay_ability": "schemas/gameplay_ability.json",
     "gameplay_tag": "schemas/gameplay_tag.json",
     "gameplay_controller": "schemas/gameplay_controller.json",
+    "input_action": "schemas/input_action.json",
+    "input_action_set": "schemas/input_action_set.json",
+    "input_mapping": "schemas/input_mapping.json",
+    "input_modifier": "schemas/input_modifier.json",
 }
 
 SCHEMA_SUFFIXES = {
@@ -29,6 +33,10 @@ SCHEMA_SUFFIXES = {
     "/schemas/gameplay_ability.json": "gameplay_ability",
     "/schemas/gameplay_tag.json": "gameplay_tag",
     "/schemas/gameplay_controller.json": "gameplay_controller",
+    "/schemas/input_action.json": "input_action",
+    "/schemas/input_action_set.json": "input_action_set",
+    "/schemas/input_mapping.json": "input_mapping",
+    "/schemas/input_modifier.json": "input_modifier",
 }
 
 

--- a/spec/part-3-asynchronous-execution/11-input-integration.adoc
+++ b/spec/part-3-asynchronous-execution/11-input-integration.adoc
@@ -7,62 +7,307 @@ The UGAS input system implements the Command pattern to decouple hardware inputs
 - Controller remapping without code changes
 - Platform-specific input schemes
 - Input buffering and queuing
-- Combo system integration
+- Context-driven input switching via Gameplay Tags
+
+The input layer defines four formal entity schemas that sit between raw hardware and the ability system:
 
 ----
 ┌──────────────┐      ┌──────────────┐      ┌──────────────┐
-│   Hardware   │─────▶│    Input     │─────▶│    Input     │
-│    Input     │      │   Action     │      │     ID       │
+│    Device    │─────▶│   Modifier   │─────▶│    Action    │
+│    Input     │      │   Pipeline   │      │   (InputID)  │
 └──────────────┘      └──────────────┘      └──────┬───────┘
                                                    │
-                                                   ▼
-                                            ┌──────────────┐
-                                            │   Ability    │
-                                            │  Activation  │
-                                            └──────────────┘
+                             ┌──────────────┐      │
+                             │  Action Set  │◀─────┘
+                             │  (context)   │
+                             └──────┬───────┘
+                                    │
+                             ┌──────────────┐
+                             │   Ability    │
+                             │  Activation  │
+                             └──────────────┘
 ----
 
-==== 11.2 Input Action to Ability Mapping
+The _Mapping_ entity connects Device Inputs to Actions, applying Modifiers along the way. Action Sets group Actions into switchable contexts driven by Gameplay Tags on the owning GC.
 
-Abilities are bound to Input IDs, which are mapped from Input Actions:
+==== 11.2 Input Actions
+
+An Input Action is a named, semantic input intent — the logical "what", not the physical "how". Actions decouple gameplay logic from hardware: an ability binds to the Action `Fire`, never to `Mouse.LeftButton`.
+
+Each Action declares a value type and a trigger behavior:
+
+[cols="2,3",options="header"]
+|===
+| Value Type
+| Description
+
+| Digital
+| Boolean on/off. Emits Started/Ongoing/Completed trigger events.
+
+| Axis1D
+| Single float axis (e.g. throttle, steering). Emits a continuous value each frame while nonzero.
+
+| Axis2D
+| Two-component vector (e.g. movement direction, camera look).
+
+| Axis3D
+| Three-component vector (e.g. VR hand position, gyroscope orientation).
+|===
+
+[cols="2,3",options="header"]
+|===
+| Trigger Behavior
+| Description
+
+| OnPressed
+| Fire once when input goes from zero to nonzero (default).
+
+| OnReleased
+| Fire once when input returns to zero.
+
+| WhileHeld
+| Fire every frame while input is nonzero.
+
+| OnTap
+| Fire once on press-then-release within `TapThreshold` seconds.
+
+| OnDoubleTap
+| Fire on two taps within `DoubleTapWindow` seconds.
+|===
 
 [source,yaml]
 ----
-InputMapping:
-  Actions:
-    - Action: "IA_PrimaryAttack"
-      InputID: "Ability.Attack.Primary"
-      KeyBindings:
-        - Key: "MouseLeft"
-        - Key: "GamepadRightTrigger"
-
-    - Action: "IA_SecondaryAttack"
-      InputID: "Ability.Attack.Secondary"
-      KeyBindings:
-        - Key: "MouseRight"
-        - Key: "GamepadLeftTrigger"
-
-    - Action: "IA_Ability1"
-      InputID: "Ability.Slot.1"
-      KeyBindings:
-        - Key: "Q"
-        - Key: "GamepadFaceLeft"
+Name: Fire
+ValueType: Digital
+TriggerBehavior: OnPressed
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Input.Type.Combat
+Metadata:
+  DisplayName: Fire Weapon
+  Category: Combat
 ----
 
-Ability grants include optional Input ID binding:
+The `Name` field is the value that `InputID` fields on `GrantedAbilities` (§4) and `WaitInputRelease` tasks (§10.3) resolve to. Implementations MUST use exact string matching between `Action.Name` and `InputID`.
 
-[source,typescript]
+`ConsumeInput` controls whether this action consumes the underlying input event. When `true` (the default), lower-priority actions bound to the same hardware input do not receive the event. When `false`, the event propagates.
+
+`Tags.ActionTags` enable bulk operations. A Gameplay Effect that grants the tag `Input.Blocked.Combat` could suppress all actions tagged `Input.Type.Combat` without listing them individually.
+
+==== 11.3 Action Sets
+
+An Action Set is a context-based group of Actions that are active together. When a player enters a vehicle, the `OnFoot` set deactivates and the `InVehicle` set activates — driven by the same tag-based activation rules that govern abilities.
+
+[source,yaml]
 ----
-GC.GrantAbility(
-  abilityClass: GA_Fireball,
-  level: 1,
-  inputID: "Ability.Slot.1"
-);
+Name: OnFoot
+Actions:
+  - Move
+  - Look
+  - Fire
+  - Aim
+  - Reload
+  - Jump
+  - Sprint
+Priority: 0
+ActivationTags:
+  RequiredTags:
+    - State.Alive
+  BlockedTags:
+    - State.InVehicle
+    - State.Cutscene
+InputBuffer:
+  Enabled: true
+  BufferWindow: 0.12
+  MaxBufferSize: 2
 ----
 
-==== 11.3 Input Buffering
+===== Activation Rules
 
-Input buffering allows players to queue inputs during animations or recovery frames:
+Action Sets activate and deactivate based on the owning GC's tag state, evaluated whenever owned tags change:
+
+1. ALL tags in `ActivationTags.RequiredTags` MUST be present on the GC (AND logic).
+2. NONE of the tags in `ActivationTags.BlockedTags` MAY be present (OR logic to block).
+3. Multiple Action Sets MAY be active simultaneously. When two active sets contain the same Action, the set with the highest `Priority` wins for that Action.
+4. When `Exclusive` is `true`, activating this set deactivates all other non-exclusive sets at the same or lower priority. This is appropriate for modal contexts (vehicle controls, cutscenes, menu navigation).
+
+The runtime SHOULD store the list of currently active Action Set names on the GC's `ActiveActionSets` field for debugging and serialization.
+
+===== Per-Set Input Buffering
+
+Each Action Set MAY override the global input buffer configuration (see §11.7). This enables per-context tuning:
+
+- Fighting games: aggressive buffering (0.1s window, 5 buffer size)
+- Platformers: moderate buffering (0.15s window, 3 buffer size)
+- Menus: no buffering (avoid accidental double-confirms)
+- Driving: no buffering (analog inputs are continuous, not event-based)
+
+==== 11.4 Device Inputs
+
+A Device Input is a canonical, engine-agnostic identifier for a physical input on a hardware device. Device Inputs are referenced inline within Mappings using a `Device` + `Input` pair — they are not standalone entity files, since hardware is a finite catalogue, not game-specific authored data.
+
+[cols="1,3",options="header"]
+|===
+| Device
+| Example Inputs
+
+| Keyboard
+| `Key.Space`, `Key.W`, `Key.LeftShift`, `Key.Escape`
+
+| Mouse
+| `Mouse.LeftButton`, `Mouse.RightButton`, `Mouse.Axis.X`, `Mouse.Axis.Y`, `Mouse.Scroll`
+
+| Gamepad
+| `Gamepad.FaceBottom` (A/Cross), `Gamepad.FaceRight` (B/Circle), `Gamepad.LeftStick.X`, `Gamepad.RightTrigger`, `Gamepad.DPad.Up`
+
+| Touch
+| `Touch.Tap`, `Touch.Region.Left`, `Touch.Swipe`
+
+| Gyro
+| `Gyro.Pitch`, `Gyro.Yaw`, `Gyro.Roll`
+
+| Custom
+| Extension point for VR controllers, flight sticks, steering wheels. Uses `CustomDeviceName` for disambiguation.
+|===
+
+Implementations MUST bridge canonical Device Input identifiers to their engine-specific equivalents at runtime. The canonical naming convention uses hierarchical dot notation: `{Category}.{Identifier}` (e.g. `Key.Space`, `Gamepad.LeftStick.X`).
+
+==== 11.5 Input Mappings
+
+A Mapping binds one or more Device Inputs to an Action, within an Action Set and optional platform context. This is the core data file that designers author to define "what button does what."
+
+[source,yaml]
+----
+ActionSet: OnFoot
+Platform: PC
+Bindings:
+  - Action: Fire
+    Inputs:
+      - Device: Mouse
+        Input: Mouse.LeftButton
+
+  - Action: Move
+    CompositeInputs:
+      Up:
+        Device: Keyboard
+        Input: Key.W
+      Down:
+        Device: Keyboard
+        Input: Key.S
+      Left:
+        Device: Keyboard
+        Input: Key.A
+      Right:
+        Device: Keyboard
+        Input: Key.D
+
+  - Action: Look
+    Inputs:
+      - Device: Mouse
+        Input: Mouse.Axis.X
+      - Device: Mouse
+        Input: Mouse.Axis.Y
+    Modifiers:
+      - MouseSensitivity
+----
+
+===== Binding Types
+
+_Simple binding_: A single Device Input maps to an Action. The most common case.
+
+_Chord binding_: Multiple Device Inputs in the `Inputs` array must all be active simultaneously for the binding to fire. Used for modifier keys (Shift+1 for an alternate ability slot). When a chord and a simple binding share an input, the chord SHOULD have a higher `Priority` to avoid the simple binding firing first.
+
+_Composite binding_: The `CompositeInputs` object composes multiple digital inputs into an axis value. The directional slots (`Up`, `Down`, `Left`, `Right`, `Forward`, `Backward`) map to a normalized vector suitable for Axis2D or Axis3D actions. This is how WASD keys produce a 2D movement vector on keyboard.
+
+===== Platform Filtering
+
+When `Platform` is set, the mapping only applies on that platform. Implementations SHOULD resolve platform at load time and discard non-matching mappings. When `Platform` is omitted, the mapping applies universally.
+
+Multiple mapping files MAY target the same Action Set with different platforms, providing platform-specific defaults:
+
+- `input_mapping_onfoot_pc.yaml` — keyboard + mouse bindings
+- `input_mapping_onfoot_gamepad.yaml` — gamepad bindings
+
+===== Rebinding
+
+Bindings with `bIsRebindable: true` (the default) SHOULD be modifiable at runtime through the remapping interface (see §11.8). Bindings with `bIsRebindable: false` are fixed and MUST NOT appear in the player's controls settings screen.
+
+==== 11.6 Input Modifiers
+
+An Input Modifier is a reusable processing step applied to raw input values as they flow through the mapping pipeline. Modifiers are standalone entities referenced by name — not inline configuration — enabling sharing across mappings and integration with player settings screens.
+
+[cols="2,3",options="header"]
+|===
+| Modifier Type
+| Description
+
+| DeadZone
+| Clamps values below `InnerThreshold` to zero and above `OuterThreshold` to 1.0. Shape is `Axial` (per-axis) or `Radial` (magnitude of 2D vector).
+
+| Sensitivity
+| Linear multiplier applied to the value. Per-axis multipliers available for 2D actions.
+
+| ResponseCurve
+| Non-linear response curve. Types: `Linear`, `Exponential` (with `Exponent`), `SCurve`, `Custom` (with explicit `CurvePoints`).
+
+| AxisInvert
+| Inverts one or more axes (`InvertX`, `InvertY`).
+
+| AxisScale
+| Scales axes by arbitrary factors (`ScaleX`, `ScaleY`, `ScaleZ`).
+
+| AxisSwizzle
+| Reorders axes (e.g. `SwizzleOrder: "YXZ"` swaps X and Y).
+
+| RadialScaling
+| Normalizes input to a maximum radius, clamping to the unit circle.
+
+| Normalize
+| Normalizes the input vector to unit length.
+
+| TriggerThreshold
+| Converts an analog value to digital: values above `PressThreshold` count as pressed.
+
+| Clamp
+| Clamps the value between `Min` and `Max`.
+
+| Custom
+| Engine-specific implementation via `CalculatorClass`.
+|===
+
+[source,yaml]
+----
+Name: StickDeadzone
+Type: DeadZone
+Params:
+  InnerThreshold: 0.15
+  OuterThreshold: 0.95
+  DeadZoneShape: Radial
+UserConfigurable: true
+Metadata:
+  DisplayName: Stick Dead Zone
+----
+
+===== Pipeline Processing
+
+Modifiers in a binding's `Modifiers` array are processed in order — the output of each modifier feeds into the next. The pipeline runs every frame for axis-type actions and on input events for digital actions.
+
+A typical gamepad stick pipeline:
+
+1. Raw stick position → `DeadZone` (eliminate drift) → `RadialScaling` (normalize to unit circle) → processed value reaches the Action.
+
+A typical mouse look pipeline:
+
+1. Raw mouse delta → `Sensitivity` (user-configurable multiplier) → processed value reaches the Action.
+
+===== User-Configurable Modifiers
+
+When `UserConfigurable` is `true`, the runtime SHOULD expose the modifier's parameters in the player's settings screen (e.g. a sensitivity slider, an invert-Y toggle, a dead zone adjustment). The modifier's `Metadata.DisplayName` provides the label for the settings UI.
+
+==== 11.7 Input Buffering
+
+Input buffering allows players to queue inputs during animations or recovery frames. The buffer configuration is specified per Action Set (see §11.3) or globally:
 
 [source,typescript]
 ----
@@ -87,17 +332,20 @@ When input buffering is enabled:
 
 [source,typescript]
 ----
-function ProcessBufferedInputs(): void {
+function ProcessBufferedInputs(actionSet: ActionSet): void {
+  const config = actionSet.InputBuffer ?? this.GlobalBufferConfig;
+  if (!config.Enabled) return;
+
   const now = GetCurrentTime();
 
   // Remove expired inputs
   this.InputBuffer = this.InputBuffer.filter(
-    input => now - input.Timestamp < this.BufferWindow
+    input => now - input.Timestamp < config.BufferWindow
   );
 
   // Process valid inputs
   for (const input of this.InputBuffer) {
-    if (TryActivateAbilityByInputID(input.InputID)) {
+    if (TryActivateAbilityByInputID(input.ActionName)) {
       break;  // Successfully activated, stop processing
     }
   }
@@ -106,29 +354,34 @@ function ProcessBufferedInputs(): void {
 }
 ----
 
-==== 11.4 Remapping Support
+Buffered inputs MUST only be processed if the Action Set that contains their Action is still active when the buffer is drained.
+
+==== 11.8 Remapping Support
 
 Input mappings SHOULD be externalizable and modifiable at runtime:
 
 [source,typescript]
 ----
 interface IInputMapper {
-  /** Get InputID for an action */
-  GetInputIDForAction(action: InputAction): InputID;
+  /** Get the active bindings for an action */
+  GetBindingsForAction(action: ActionName): Binding[];
 
-  /** Remap an action to a new key */
-  RemapAction(action: InputAction, newKey: Key): void;
+  /** Remap a binding to a new device input */
+  RemapBinding(action: ActionName, oldInput: DeviceInput, newInput: DeviceInput): void;
 
-  /** Reset to defaults */
-  ResetToDefaults(): void;
+  /** Reset all bindings to defaults for an action set */
+  ResetToDefaults(actionSet: ActionSetName): void;
 
-  /** Save current mappings */
+  /** Save current mappings to persistent storage */
   SaveMappings(): void;
 
-  /** Load saved mappings */
+  /** Load saved mappings from persistent storage */
   LoadMappings(): void;
 }
 ----
 
-'''
+Implementations MUST respect the `bIsRebindable` flag on bindings. Only bindings with `bIsRebindable: true` SHOULD be presented in the controls settings UI and accepted by `RemapBinding`.
 
+When a player remaps a binding, the runtime SHOULD check for conflicts (two bindings in the same Action Set using the same Device Input) and either warn the player or swap the conflicting binding.
+
+'''


### PR DESCRIPTION
## Summary

Closes #52

- Add four new entity schemas (`input_action`, `input_action_set`, `input_mapping`, `input_modifier`) in both YAML and JSON, following existing patterns (Draft-07, PascalCase, `$defs` for shared types)
- Define `DeviceInput` as an inline `$defs` type within the Mapping schema — engine-agnostic canonical identifiers for keyboard, mouse, gamepad, touch, gyro, and custom devices
- Add schema examples, genre templates, and input entity files for all four genre packs (shooter, action/platformer, racing, RPG)
- Update the Gameplay Controller schema with `ActiveActionSets` and an enriched `InputID` description referencing Action entities
- Expand spec section 11 from 134 lines of prose to ~280 lines with eight subsections: Command Pattern Overview, Input Actions, Action Sets, Device Inputs, Input Mappings, Input Modifiers, Input Buffering, Remapping Support
- Update `compare_schema_definitions.py` and `validate_schema_examples.py` to cover the four new schema pairs (10 total, 101 validated snippets)

## Test plan

- [x] `python3 scripts/compare_schema_definitions.py` passes (10 JSON/YAML pairs equivalent)
- [x] `python3 scripts/validate_schema_examples.py` passes (101 snippets validated)
- [x] Spot-check genre pack YAML files reference correct `$schema` URLs
- [x] Review spec section 11 renders correctly in AsciiDoc