### PR TITLE
fix: sync revdate in SPEC.adoc during version bumps

### DIFF
--- a/SPEC.adoc
+++ b/SPEC.adoc
@@ -1,7 +1,7 @@
 = Universal Gameplay Ability System Specification
 Mickael Bonfill <jbltx>
 :revnumber: 1.0.0-draft.3
-:revdate: February 2026
+:revdate: June 2026
 :ugas-version: v1.0.0-draft.3
 :doctype: book
 :toc: left

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -8,6 +8,7 @@ of truth for the UGAS version.
 import json
 import pathlib
 import re
+from datetime import datetime
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 
@@ -17,7 +18,9 @@ def main() -> None:
 
     spec = ROOT / "SPEC.adoc"
     text = spec.read_text()
+    revdate = datetime.now().strftime("%B %Y")
     text = re.sub(r"^:revnumber:.*$", f":revnumber: {version}", text, count=1, flags=re.M)
+    text = re.sub(r"^:revdate:.*$", f":revdate: {revdate}", text, count=1, flags=re.M)
     text = re.sub(r"^:ugas-version:.*$", f":ugas-version: v{version}", text, count=1, flags=re.M)
     spec.write_text(text)
 


### PR DESCRIPTION
## Summary

The `sync_version.py` script updated `:revnumber:` and `:ugas-version:` on each changeset release but left `:revdate:` hardcoded to `February 2026`. Now it writes the current month and year (e.g. `June 2026`) automatically.

- Add `datetime` import and `:revdate:` substitution to `scripts/sync_version.py`
- Update `SPEC.adoc` to the current date (`June 2026`)
- The Document History table entry stays fixed (historical record of v1.0 authoring)

## Test plan

- [x] Run `python3 scripts/sync_version.py` — verify `:revdate:` in `SPEC.adoc` is updated to current month/year
- [x] Verify Document History table (line 297) is unchanged