### PR TITLE
feat: state persistence protocol for active effects

### DIFF
--- a/.changeset/state-persistence-protocol.md
+++ b/.changeset/state-persistence-protocol.md
@@ -1,0 +1,5 @@
+---
+'ugas': minor
+---
+
+[Added] State Persistence protocol (§14): defines how active effect state is serialized and restored — remaining-seconds duration encoding, infinite effect provenance tracking, periodic execution mid-cycle capture, and execution policy queue serialization. Includes a full GC snapshot structure, ordered restoration protocol, and offline duration advancement guidance. Updates GC schema with `DurationPolicy`, `RemainingDuration`, `SourceAbility`, `PeriodicState`, `CapturedAttributes`, and `SetByCallerMagnitudes` fields. Closes #6.

--- a/schemas/gameplay_controller.json
+++ b/schemas/gameplay_controller.json
@@ -175,7 +175,7 @@
           }
         }
       },
-      "description": "Currently active effects applied to this GC (serialization protocol: §14)"
+      "description": "Currently active effects applied to this GC (serialization protocol §14)"
     },
     "ActiveActionSets": {
       "type": "array",

--- a/schemas/gameplay_controller.json
+++ b/schemas/gameplay_controller.json
@@ -112,9 +112,14 @@
             "type": "string",
             "description": "GameplayEffect class reference"
           },
-          "Duration": {
+          "DurationPolicy": {
+            "type": "string",
+            "enum": ["HasDuration", "Infinite"],
+            "description": "Duration policy of the originating effect (§14.3)"
+          },
+          "RemainingDuration": {
             "type": "number",
-            "description": "Remaining duration in seconds (-1 for infinite)"
+            "description": "Remaining duration in seconds. Present only for HasDuration effects (§14.3.1)"
           },
           "Stacks": {
             "type": "integer",
@@ -134,10 +139,43 @@
           "InstigatorGC": {
             "type": "string",
             "description": "Reference to the GC that caused this effect"
+          },
+          "SourceAbility": {
+            "type": "string",
+            "description": "Ability that applied this effect (for provenance tracking, §14.3.2)"
+          },
+          "PeriodicState": {
+            "type": "object",
+            "description": "Periodic execution state for effects with Period settings (§14.3.3)",
+            "properties": {
+              "PeriodElapsed": {
+                "type": "number",
+                "description": "Seconds elapsed since last periodic execution"
+              },
+              "ExecutionCount": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Total periodic executions fired"
+              }
+            }
+          },
+          "CapturedAttributes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            },
+            "description": "Attribute values captured OnApplication, keyed by attribute name (§14.3)"
+          },
+          "SetByCallerMagnitudes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            },
+            "description": "Runtime-provided magnitudes, keyed by data tag (§14.3)"
           }
         }
       },
-      "description": "Currently active effects applied to this GC"
+      "description": "Currently active effects applied to this GC (serialization protocol: §14)"
     },
     "ActiveActionSets": {
       "type": "array",

--- a/schemas/gameplay_controller.yaml
+++ b/schemas/gameplay_controller.yaml
@@ -94,9 +94,15 @@ properties:
         EffectClass:
           type: string
           description: GameplayEffect class reference
-        Duration:
+        DurationPolicy:
+          type: string
+          enum: [HasDuration, Infinite]
+          description: Duration policy of the originating effect (§14.3)
+        RemainingDuration:
           type: number
-          description: Remaining duration in seconds (-1 for infinite)
+          description: >-
+            Remaining duration in seconds. Present only for HasDuration
+            effects (§14.3.1)
         Stacks:
           type: integer
           minimum: 1
@@ -112,7 +118,38 @@ properties:
         InstigatorGC:
           type: string
           description: Reference to the GC that caused this effect
-    description: Currently active effects applied to this GC
+        SourceAbility:
+          type: string
+          description: >-
+            Ability that applied this effect (for provenance tracking,
+            §14.3.2)
+        PeriodicState:
+          type: object
+          description: >-
+            Periodic execution state for effects with Period settings
+            (§14.3.3)
+          properties:
+            PeriodElapsed:
+              type: number
+              description: Seconds elapsed since last periodic execution
+            ExecutionCount:
+              type: integer
+              minimum: 0
+              description: Total periodic executions fired
+        CapturedAttributes:
+          type: object
+          additionalProperties:
+            type: number
+          description: >-
+            Attribute values captured OnApplication, keyed by attribute
+            name (§14.3)
+        SetByCallerMagnitudes:
+          type: object
+          additionalProperties:
+            type: number
+          description: >-
+            Runtime-provided magnitudes, keyed by data tag (§14.3)
+    description: Currently active effects applied to this GC (serialization protocol §14)
 
   ActiveActionSets:
     type: array

--- a/schemas/gameplay_effect.json
+++ b/schemas/gameplay_effect.json
@@ -181,7 +181,7 @@
         },
         "Channel": {
           "type": "string",
-          "description": "Optional named aggregation channel. Modifiers in the same channel sum together; modifiers in different channels multiply against each other. Used for damage-bucket systems (see §15.3). Defaults to the global channel if omitted."
+          "description": "Optional named aggregation channel. Modifiers in the same channel sum together; modifiers in different channels multiply against each other. Used for damage-bucket systems (see §16.3). Defaults to the global channel if omitted."
         }
       }
     }

--- a/schemas/gameplay_effect.yaml
+++ b/schemas/gameplay_effect.yaml
@@ -169,4 +169,4 @@ $defs:
         description: >-
           Optional named aggregation channel. Modifiers in the same channel sum together;
           modifiers in different channels multiply against each other. Used for damage-bucket
-          systems (see §15.3). Defaults to the global channel if omitted.
+          systems (see §16.3). Defaults to the global channel if omitted.

--- a/spec/part-4-feedback-and-networking.adoc
+++ b/spec/part-4-feedback-and-networking.adoc
@@ -1,5 +1,7 @@
-== Part IV: Feedback and Networking
+== Part IV: Feedback, Networking, and Persistence
 
 include::part-4-feedback-and-networking/12-gameplay-cues.adoc[]
 
 include::part-4-feedback-and-networking/13-network-replication.adoc[]
+
+include::part-4-feedback-and-networking/14-state-persistence.adoc[]

--- a/spec/part-4-feedback-and-networking/14-state-persistence.adoc
+++ b/spec/part-4-feedback-and-networking/14-state-persistence.adoc
@@ -1,0 +1,262 @@
+=== 14. State Persistence
+
+==== 14.1 Overview
+
+UGAS defines a persistence protocol so that the runtime state of a Gameplay Controller — attributes, active effects, granted abilities, and owned tags — can be captured, serialized, and restored. The primary use cases are:
+
+- _Save / Load_ in single-player games ("save anywhere" support)
+- _Reconnection_ in multiplayer — restoring a player's GC after a disconnect
+- _Server migration_ — transferring authoritative GC state between server processes
+- _Replay systems_ — recording and replaying gameplay state at arbitrary points
+
+Attribute Sets are the serialization boundary for attribute data (§6.1). This section defines the complementary protocol for active effect state, which is the primary source of complexity in GC persistence.
+
+==== 14.2 GC State Snapshot
+
+A complete GC snapshot MUST contain:
+
+[cols="2,3,2",options="header"]
+|===
+| Component
+| Content
+| Restoration Order
+
+| Attribute Sets
+| Base Values for every registered attribute
+| 1 — restore first
+
+| Active Effects
+| One `ActiveEffectRecord` per active effect (see §14.3)
+| 2 — re-apply after attributes
+
+| Granted Abilities
+| Ability class, level, input binding, grant source
+| 3 — after effects (some are effect-granted)
+
+| Owned Tags
+| Tag grant counts
+| Derived — reconstructed from restored effects
+|===
+
+Current Values and Owned Tags are _derived state_: they are recomputed when active effects are re-applied to the restored Base Values. Implementations MUST NOT serialize Current Values or tag grant counts as authoritative state; they exist in the snapshot only for debugging and validation.
+
+[source,typescript]
+----
+struct GCSnapshot {
+  /** Monotonic snapshot version for forward-compatibility checks */
+  Version: integer;
+
+  /** Reference to the snapshotted GC */
+  OwnerActorID: string;
+
+  /** Wall-clock or game-time at capture */
+  CaptureTimestamp: number;
+
+  /** Base Values, keyed by AttributeSet then Attribute name */
+  AttributeSets: SerializedAttributeSet[];
+
+  /** Every active (non-Instant) effect */
+  ActiveEffects: ActiveEffectRecord[];
+
+  /** Granted abilities not sourced from an active effect */
+  GrantedAbilities: SerializedAbilityGrant[];
+}
+----
+
+==== 14.3 Active Effect Record
+
+Each active effect (`HasDuration` or `Infinite`) is serialized as an `ActiveEffectRecord`. Instant effects modify Base Values directly and leave no active state; they are captured implicitly via the attribute snapshot.
+
+[source,typescript]
+----
+struct ActiveEffectRecord {
+  /** Unique handle — preserved across save/load for external references */
+  Handle: string;
+
+  /** Effect class identifier (references a GameplayEffect definition) */
+  EffectClass: string;
+
+  /** Duration policy of the originating effect */
+  DurationPolicy: "HasDuration" | "Infinite";
+
+  /** Effect level at time of application */
+  Level: integer;
+
+  /** GC that applied this effect */
+  InstigatorGC: string;
+
+  /** Ability that applied this effect (if any) */
+  SourceAbility?: string;
+
+  /** Remaining duration in seconds. Present only for HasDuration effects. */
+  RemainingDuration?: number;
+
+  /** Periodic execution state. Present only for periodic effects. */
+  PeriodicState?: PeriodicExecutionState;
+
+  /** Execution policy state for multi-instance effects */
+  ExecutionPolicyState?: ExecutionPolicyState;
+
+  /** Number of active instances (RunInParallel) or queued+active instances (RunInSequence) */
+  InstanceCount: integer;
+
+  /** Attribute values captured OnApplication (frozen at apply-time) */
+  CapturedAttributes?: Map<string, number>;
+
+  /** SetByCaller magnitudes set at application time */
+  SetByCallerMagnitudes?: Map<string, number>;
+}
+----
+
+===== 14.3.1 Duration Encoding
+
+`HasDuration` effects MUST serialize remaining time as _seconds remaining_, not as an absolute wall-clock or game-time deadline.
+
+[cols="2,3",options="header"]
+|===
+| Field
+| Semantics
+
+| `RemainingDuration`
+| Seconds of effect time remaining at the moment of capture. On restore, the effect timer resumes from this value.
+|===
+
+Rationale: absolute timestamps couple serialized state to the clock source. Remaining-seconds is portable across sessions, servers, and time zones. The `CaptureTimestamp` on the snapshot provides the reference point if an implementation needs to compute how much time has elapsed since capture (e.g., to expire effects during an offline period — see §14.5).
+
+===== 14.3.2 Infinite Effect Intent
+
+Infinite effects have no expiry timer, which raises a cleanup concern: is an Infinite effect _intended to persist indefinitely_ (e.g., an equipment passive) or was it _leaked_ by a bug?
+
+The serialization protocol addresses this through provenance tracking: every `ActiveEffectRecord` with `DurationPolicy: Infinite` MUST carry an `InstigatorGC`, a `SourceAbility`, or both. On restoration, implementations SHOULD validate that the instigator and/or source ability still exist. If neither reference resolves, the implementation SHOULD log a warning and MAY discard the effect.
+
+Implementations MAY additionally define a `Gameplay.Effect.Persistent` tag on effect definitions that are _designed_ to survive serialization boundaries. Effects without this tag MAY be stripped during save if the game design requires it (e.g., clearing temporary combat buffs on zone transition or session end). This is a game-design decision, not a spec mandate — the tag provides a declarative mechanism for expressing the intent.
+
+===== 14.3.3 Periodic Execution State
+
+For effects with `Period` settings (§9.3), the serialization record MUST capture where the effect is within its current period cycle:
+
+[source,typescript]
+----
+struct PeriodicExecutionState {
+  /** Seconds elapsed since the last periodic execution */
+  PeriodElapsed: number;
+
+  /** Total number of periodic executions that have fired */
+  ExecutionCount: integer;
+}
+----
+
+On restoration:
+
+1. The period timer resumes from `PeriodElapsed`, counting toward the next execution at the configured `Period` interval.
+2. The effect MUST NOT re-execute for the current period on load. A periodic tick fires only when the resumed timer reaches the next period boundary.
+3. `ExecutionCount` is preserved for effects whose logic depends on how many times they have executed (e.g., escalating damage over time).
+
+===== 14.3.4 Execution Policy State
+
+====== RunInParallel
+
+Each concurrent instance is serialized as an independent `ActiveEffectRecord` sharing the same `EffectClass`. `InstanceCount` records the total number of simultaneously active instances. On restore, all instances resume independently with their own timers.
+
+====== RunInSequence
+
+Queued instances that are waiting (not yet active) MUST also be serialized. The queue is represented by an ordered list of handles:
+
+[source,typescript]
+----
+struct SequenceQueueState {
+  /** Ordered handles of instances — first element is the currently active instance */
+  Queue: string[];
+}
+----
+
+The active instance (head of the queue) carries its own `RemainingDuration` and `PeriodicState`. Queued instances retain their full configured duration — they have not started yet. On restore, the GC reconstructs the queue: the head instance resumes with its saved timer state, and queued instances wait in order.
+
+====== RunInMerge
+
+A merged effect is a single logical instance regardless of how many times it was applied. The serialized record carries the merged remaining duration (time until the latest-ending application would have expired) and the merge count:
+
+[source,typescript]
+----
+struct MergeState {
+  /** Number of applications that were merged into this instance */
+  MergeCount: integer;
+}
+----
+
+==== 14.4 Restoration Protocol
+
+Restoring a GC from a snapshot MUST follow this sequence:
+
+1. **Restore Attribute Base Values.** For each `SerializedAttributeSet`, set each attribute's Base Value. Do NOT recompute Current Values yet.
+
+2. **Re-apply Active Effects.** For each `ActiveEffectRecord`, reconstruct the `EffectSpec` from the stored `EffectClass` definition, `Level`, `SetByCallerMagnitudes`, and `CapturedAttributes`. Apply the effect to the GC using the restoration overrides (duration from `RemainingDuration`, periodic state from `PeriodicState`). The effect pipeline runs normally — modifiers are added, Tags are granted, Abilities are granted — but timers are initialized from the serialized state rather than from the effect's configured values.
+
+3. **Restore Granted Abilities.** Re-grant abilities that were not sourced from an active effect. Effect-granted abilities are restored automatically in step 2.
+
+4. **Recompute Current Values.** With all modifiers back in place, trigger a full attribute recalculation. The resulting Current Values SHOULD match the pre-save state.
+
+5. **Validate.** Implementations SHOULD compare restored Current Values and Owned Tags against any debug/validation copies stored in the snapshot. Mismatches indicate a restoration error or a data definition change between save and load.
+
+[source,typescript]
+----
+function RestoreGC(gc: GameplayController, snapshot: GCSnapshot): void {
+  // 1. Attributes
+  for (const set of snapshot.AttributeSets) {
+    const attrSet = gc.GetAttributeSet(set.Name);
+    for (const attr of set.Attributes) {
+      attrSet.SetBaseValue(attr.Name, attr.BaseValue);
+    }
+  }
+
+  // 2. Active Effects — order matters for RunInSequence queues
+  for (const record of snapshot.ActiveEffects) {
+    const spec = ReconstructEffectSpec(record);
+    gc.ApplyGameplayEffect(spec, {
+      ResumeRemainingDuration: record.RemainingDuration,
+      ResumePeriodicState: record.PeriodicState,
+      RestoredHandle: record.Handle
+    });
+  }
+
+  // 3. Non-effect-granted Abilities
+  for (const grant of snapshot.GrantedAbilities) {
+    gc.GrantAbility(grant.AbilityClass, grant.Level, grant.InputID);
+  }
+
+  // 4. Recompute
+  gc.RecalculateAllAttributes();
+}
+----
+
+==== 14.5 Offline Duration Advancement
+
+For single-player games where real time passes between save and load (e.g., mobile idle games), implementations MAY advance effect timers by the elapsed real time:
+
+[source,typescript]
+----
+function AdvanceOfflineTime(
+  snapshot: GCSnapshot,
+  currentTime: number
+): void {
+  const elapsed = currentTime - snapshot.CaptureTimestamp;
+
+  for (const record of snapshot.ActiveEffects) {
+    if (record.DurationPolicy === "HasDuration" && record.RemainingDuration != null) {
+      record.RemainingDuration -= elapsed;
+      if (record.RemainingDuration <= 0) {
+        // Effect expired while offline — remove from snapshot before restore
+        continue;
+      }
+    }
+    if (record.PeriodicState) {
+      record.PeriodicState.PeriodElapsed += elapsed;
+    }
+  }
+}
+----
+
+Whether to execute missed periodic ticks (batch-fire accumulated executions) or simply advance the timer is a game-design decision. The spec does not mandate either behavior; implementations SHOULD document their choice.
+
+'''
+

--- a/spec/part-5-reference-implementation.adoc
+++ b/spec/part-5-reference-implementation.adoc
@@ -1,5 +1,5 @@
 == Part V: Reference Implementation
 
-include::part-5-reference-implementation/14-implementation-examples.adoc[]
+include::part-5-reference-implementation/15-implementation-examples.adoc[]
 
-include::part-5-reference-implementation/15-case-studies.adoc[]
+include::part-5-reference-implementation/16-case-studies.adoc[]

--- a/spec/part-5-reference-implementation/15-implementation-examples.adoc
+++ b/spec/part-5-reference-implementation/15-implementation-examples.adoc
@@ -1,6 +1,6 @@
-=== 14. Implementation Examples
+=== 15. Implementation Examples
 
-==== 14.1 Basic Damage Application
+==== 15.1 Basic Damage Application
 
 ===== Effect Definition
 
@@ -70,7 +70,7 @@ class HealthObserver implements IAttributeChangeObserver {
 }
 ----
 
-==== 14.2 Buff/Debuff with Duration
+==== 15.2 Buff/Debuff with Duration
 
 ===== Temporary Modifier
 
@@ -126,7 +126,7 @@ class GC_Status_StrengthBuff extends GameplayCueLooping {
 }
 ----
 
-==== 14.3 Ability with Cast Time
+==== 15.3 Ability with Cast Time
 
 [source,yaml]
 ----
@@ -195,7 +195,7 @@ class GA_Fireball extends GameplayAbility {
 }
 ----
 
-==== 14.4 Complex Calculation (Armor Penetration)
+==== 15.4 Complex Calculation (Armor Penetration)
 
 [source,typescript]
 ----

--- a/spec/part-5-reference-implementation/16-case-studies.adoc
+++ b/spec/part-5-reference-implementation/16-case-studies.adoc
@@ -1,6 +1,6 @@
-=== 15. Case Studies
+=== 16. Case Studies
 
-==== 15.1 Platformer (Mario-style)
+==== 16.1 Platformer (Mario-style)
 
 ===== Movement Attributes
 
@@ -122,7 +122,7 @@ GameplayCues:
   - "GameplayCue.PowerUp.Super"
 ----
 
-==== 15.2 Racing (Forza-style)
+==== 16.2 Racing (Forza-style)
 
 ===== Vehicle Attribute Sets
 
@@ -236,7 +236,7 @@ class ExecCalc_VehicleTraction extends ExecutionCalculation {
 }
 ----
 
-==== 15.3 ARPG (Diablo-style)
+==== 16.3 ARPG (Diablo-style)
 
 ===== Damage Bucket Architecture
 
@@ -428,7 +428,7 @@ class ItemEquipSystem {
 }
 ----
 
-==== 15.4 Puzzle (2048-style)
+==== 16.4 Puzzle (2048-style)
 
 ===== Grid Cell Attributes
 


### PR DESCRIPTION
## Summary

- Adds **Section 14: State Persistence** to Part IV, defining a serialization protocol for active effect state on Gameplay Controllers
- Answers the four open questions from #6:
  - **HasDuration** → remaining-seconds encoding (portable across sessions/servers)
  - **Infinite effects** → provenance tracking via `InstigatorGC`/`SourceAbility` + optional `Gameplay.Effect.Persistent` tag
  - **Periodic effects** → `PeriodicState` captures mid-cycle elapsed time and execution count; no re-execution on load
  - **RunInSequence queues** → full queue serialization with ordered handles; also covers RunInParallel and RunInMerge
- Defines a `GCSnapshot` structure, ordered restoration protocol, and offline duration advancement
- Updates `gameplay_controller.json`/`.yaml` schema with `DurationPolicy`, `RemainingDuration`, `SourceAbility`, `PeriodicState`, `CapturedAttributes`, `SetByCallerMagnitudes`
- Renumbers Part V sections (14→15, 15→16) and updates `§15.3` → `§16.3` cross-references

Closes #6

## Test plan

- [x] Verify spec renders correctly with AsciiDoc toolchain (all includes resolve, section numbering is sequential)
- [x] Confirm `gameplay_controller.json` passes JSON Schema validation
- [x] Check all `§` cross-references in spec and schemas point to the correct sections
- [x] Review new §14 content for normative language consistency (MUST/SHOULD/MAY usage)