### PR TITLE
feat: add Combat genre pack (genres/combat) (#38)

### DIFF
--- a/.changeset/genre-pack-combat.md
+++ b/.changeset/genre-pack-combat.md
@@ -1,0 +1,5 @@
+---
+'ugas': minor
+---
+
+[Added] Combat genre pack (`genres/combat/`): an additive fighting/brawler/hack-and-slash specification plus a schema-conformant template — `FighterCombatSet` (health, a poise/stagger meter, a guard/block-stamina meter, a super gauge, and frame-data feel stats), a combat tag taxonomy (frame-data + stagger states, startup/active/recovery move phases, ability types, hitzones, teams), the signature melee exchange (frame-data hitstun/blockstun states that block actions, a poise → stagger threshold that applies `GE_Stagger`, a `Block` damage channel that reduces incoming damage and slows movement, and combo cancels via `CancelAbilitiesWithTags` / `BlockAbilitiesWithTags`), light/heavy/block/special abilities with a meter-cost super and super-freeze lockout, a custom `ExecCalc_MeleeResolution` Execution coupling AttackPower, Defense, the Block channel, poise/guard damage, and super gain into `EffectiveDamage`, a gamepad input layer, and a worked mid-block fighter controller. Designed from first principles as a ready-to-extend pack, deliberately distinct from the Shooter pack (#38).

--- a/genres/README.md
+++ b/genres/README.md
@@ -94,3 +94,4 @@ schema, example, and genre-pack entity in one file).
 | `racing` | Racing (Forza-style) — seeded by the Racing case study | [`racing/spec.adoc`](racing/spec.adoc) |
 | `action` | Action / Action-Adventure — seeded by the Platformer case study | [`action/spec.adoc`](action/spec.adoc) |
 | `shooter` | Shooter (FPS/TPS) — gunplay, ammo economy, hit resolution | [`shooter/spec.adoc`](shooter/spec.adoc) |
+| `combat` | Combat (fighting/brawler/hack-and-slash) — frame-data states, poise→stagger, guard channel | [`combat/spec.adoc`](combat/spec.adoc) |

--- a/genres/combat/README.md
+++ b/genres/combat/README.md
@@ -1,0 +1,51 @@
+# UGAS Genre Pack: Combat
+
+> Skill-based melee dueling (fighting / brawler / hack-and-slash): frame-data states (hitstun &
+> blockstun), a poise → stagger meter that opens punish windows, a guard/block damage channel that
+> trades chip and mobility for safety, a super meter spent on specials, and combo cancels expressed
+> through ability block/cancel tags — the core of the wider Combat family.
+
+This pack is a copy-and-extend starting point for melee combat games. It is *additive*: it defines
+genre-specific Attributes, Tags, Abilities, and Effects on top of the core UGAS spec and never
+redefines a core concept. There is no dedicated fighting case study in the core spec, so the pack is
+designed from first principles and grounded in the genre's standard frame-data mechanics. It is
+deliberately distinct from the Shooter pack: melee instead of projectiles, frame phases instead of
+ammo, a guard meter and a stagger meter instead of reloads and falloff.
+
+## What's in this pack
+
+| File | Purpose |
+|------|---------|
+| `spec.adoc` | Additional Combat specification — extends, never replaces, the core spec |
+| `entities/attribute_set.yaml` | `FighterCombatSet`: health, poise/stagger and guard meters, super gauge, frame-data stats |
+| `entities/tag_registry.yaml` | Combat tags: frame-data + stagger states, move phases, ability types, hitzones, teams |
+| `entities/effect_melee_damage.yaml` | `GE_MeleeDamage`: hit resolution (damage, poise, guard, super) via a custom Execution |
+| `entities/effect_hitstun.yaml` | `GE_Hitstun`: clean-hit recovery state that blocks all actions |
+| `entities/effect_blockstun.yaml` | `GE_Blockstun`: blocked-hit recovery state that blocks all actions |
+| `entities/effect_blocking.yaml` | `GE_Blocking`: Block-channel damage reduction + slower movement while guarding |
+| `entities/effect_stagger.yaml` | `GE_Stagger`: poise-break punish window, applied by the engine Poise==0 threshold |
+| `entities/ability_light_attack.yaml` | `GA_LightAttack`: fast combo starter; cancellable into a heavy |
+| `entities/ability_heavy_attack.yaml` | `GA_HeavyAttack`: slow heavy blow that cancels light-attack recovery |
+| `entities/ability_block.yaml` | `GA_Block`: hold to guard (Block channel), blockstun instead of hitstun on contact |
+| `entities/ability_special.yaml` | `GA_Special`: spend a full super bar; super-freeze locks out the opponent |
+| `entities/input_actions.yaml` | Brawl input actions: light, heavy, block, special, move |
+| `entities/input_action_set_brawl.yaml` | `Brawl`: the in-match input context with combo-friendly buffering |
+| `entities/input_mapping_brawl_gamepad.yaml` | Gamepad bindings: two attacks, special, hold-block, stick movement |
+| `entities/input_modifiers.yaml` | Reusable input modifiers (stick dead zone, radial scaling, trigger threshold) |
+| `entities/gameplay_controller.yaml` | Worked example: a fighter mid-block that just ate a heavy hit |
+
+## How to use
+
+1. Read `spec.adoc` for the genre-specific design (especially the melee exchange — frame-data
+   states, the cancel tags, the Block damage channel, and the poise → stagger threshold).
+2. Copy the entity files in `entities/` into your project and adapt them — tune the fighter base
+   values in `attribute_set.yaml`, add moves as new Abilities + `GE_MeleeDamage` payloads, add
+   defensive layers in their own `Channel`, or wire the one `ExecCalc_MeleeResolution` hook in your
+   engine.
+3. They validate against the core `schemas/*.yaml`, so AI agents (e.g. the `ugas-schema-author`
+   skill) can load and extend them directly.
+4. Run `python scripts/validate_schema_examples.py` after changes.
+
+## Published spec
+
+<!-- Link to the built HTML once published, e.g. v<version>/genres/combat/index.html -->

--- a/genres/combat/README.md
+++ b/genres/combat/README.md
@@ -27,7 +27,7 @@ ammo, a guard meter and a stagger meter instead of reloads and falloff.
 | `entities/ability_light_attack.yaml` | `GA_LightAttack`: fast combo starter; cancellable into a heavy |
 | `entities/ability_heavy_attack.yaml` | `GA_HeavyAttack`: slow heavy blow that cancels light-attack recovery |
 | `entities/ability_block.yaml` | `GA_Block`: hold to guard (Block channel), blockstun instead of hitstun on contact |
-| `entities/ability_special.yaml` | `GA_Special`: spend a full super bar; super-freeze locks out the opponent |
+| `entities/ability_special.yaml` | `GA_Special`: spend a full super bar; super-freeze locks the user out of their own normals (committed to the super) |
 | `entities/input_actions.yaml` | Brawl input actions: light, heavy, block, special, move |
 | `entities/input_action_set_brawl.yaml` | `Brawl`: the in-match input context with combo-friendly buffering |
 | `entities/input_mapping_brawl_gamepad.yaml` | Gamepad bindings: two attacks, special, hold-block, stick movement |

--- a/genres/combat/entities/ability_block.yaml
+++ b/genres/combat/entities/ability_block.yaml
@@ -1,0 +1,33 @@
+# Block: hold to guard. Applies GE_Blocking (Block-channel damage reduction, slower movement,
+# Combat.State.Blocking), waits for the block input to release, then removes it - the same
+# hold-then-WaitInputRelease shape as the shooter's aim-down-sights and the platformer jump.
+# While Combat.State.Blocking is owned, incoming hits resolve through the calc's blocked-hit branch
+# (reduced damage + guard damage + blockstun) instead of a clean hit. Cannot raise guard while in
+# hitstun, blockstun, or staggered. Holding guard chips GuardHealth on each blocked hit; when it
+# empties, the engine breaks the guard (a separate guard-break flow), so blocking is not free.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
+Name: GA_Block
+Tags:
+  AbilityTags:
+    - Ability.Type.Block
+  ActivationRequiredTags:
+    - State.Combat
+  ActivationBlockedTags:
+    - Combat.State.Hitstun
+    - Combat.State.Blockstun
+    - Combat.State.Staggered
+Tasks:
+  - Type: ApplyEffectToOwner
+    Params:
+      EffectClass: GE_Blocking
+  - Type: WaitInputRelease
+    Params:
+      InputID: Block
+  - Type: RemoveEffectFromOwner
+    Params:
+      EffectClass: GE_Blocking
+Metadata:
+  DisplayName: Block
+  Description: Hold to guard, reducing damage and gaining blockstun instead of hitstun on contact
+  Icon: ui/icons/block.png

--- a/genres/combat/entities/ability_heavy_attack.yaml
+++ b/genres/combat/entities/ability_heavy_attack.yaml
@@ -1,0 +1,43 @@
+# Heavy attack: the slow, high-damage normal and the combo's cancel target. Longer startup and
+# recovery than the light, but it deals far more damage, poise damage, and guard damage (all carried
+# by GE_MeleeDamage and resolved by ExecCalc_MeleeResolution). Its CancelAbilitiesWithTags lists
+# Ability.Type.Light, so activating the heavy during a light attack's recovery CANCELS that light -
+# this is the light->heavy combo cancel expressed purely with tags. Cannot start while in hitstun,
+# blockstun, staggered, or blocking.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
+Name: GA_HeavyAttack
+Tags:
+  AbilityTags:
+    - Ability.Type.Heavy
+  CancelAbilitiesWithTags:
+    - Ability.Type.Light
+  ActivationRequiredTags:
+    - State.Combat
+  ActivationBlockedTags:
+    - Combat.State.Hitstun
+    - Combat.State.Blockstun
+    - Combat.State.Staggered
+    - Combat.State.Blocking
+  ActivationOwnedTags:
+    - Combat.Move.Recovery
+Cooldown: GE_HeavyAttackCooldown
+Tasks:
+  - Type: WaitDelay
+    Params:
+      Duration: 0.2
+  - Type: WaitTargetData
+    Params:
+      TargetingMethod: MeleeSweep
+      MaxRange: 1.8
+      Hitzone: Hitzone.High
+  - Type: ApplyEffectToTarget
+    Params:
+      EffectClass: GE_MeleeDamage
+  - Type: WaitDelay
+    Params:
+      Duration: 0.35
+Metadata:
+  DisplayName: Heavy Attack
+  Description: A slow, heavy blow that cancels light-attack recovery and deals heavy poise/guard damage
+  Icon: ui/icons/heavy_attack.png

--- a/genres/combat/entities/ability_light_attack.yaml
+++ b/genres/combat/entities/ability_light_attack.yaml
@@ -1,0 +1,41 @@
+# Light attack: the fast combo starter. Quick startup, short recovery, low damage. Walks the
+# three frame phases (Combat.Move.Startup -> Active -> Recovery) via its ActivationOwnedTags and the
+# task sequence, applying GE_MeleeDamage to the target during the Active window. It owns
+# Combat.Move.Recovery during its tail, which is exactly the tag GA_HeavyAttack's
+# CancelAbilitiesWithTags cancels - so a heavy buffered during light recovery interrupts it,
+# the basic combo cancel. Cannot start while in hitstun, blockstun, staggered, or blocking.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
+Name: GA_LightAttack
+Tags:
+  AbilityTags:
+    - Ability.Type.Light
+  ActivationRequiredTags:
+    - State.Combat
+  ActivationBlockedTags:
+    - Combat.State.Hitstun
+    - Combat.State.Blockstun
+    - Combat.State.Staggered
+    - Combat.State.Blocking
+  ActivationOwnedTags:
+    - Combat.Move.Recovery
+Cooldown: GE_LightAttackCooldown
+Tasks:
+  - Type: WaitDelay
+    Params:
+      Duration: 0.08
+  - Type: WaitTargetData
+    Params:
+      TargetingMethod: MeleeSweep
+      MaxRange: 1.5
+      Hitzone: Hitzone.Mid
+  - Type: ApplyEffectToTarget
+    Params:
+      EffectClass: GE_MeleeDamage
+  - Type: WaitDelay
+    Params:
+      Duration: 0.18
+Metadata:
+  DisplayName: Light Attack
+  Description: A fast jab that starts combos; cancellable into a heavy attack
+  Icon: ui/icons/light_attack.png

--- a/genres/combat/entities/ability_special.yaml
+++ b/genres/combat/entities/ability_special.yaml
@@ -1,0 +1,46 @@
+# Special: the meter-spending super move. Costs a full bar of Super (Cost: GE_SuperCost, a trivial
+# resource cost referenced by name like the racing pack's nitro cost) and so cannot activate on an
+# empty gauge - the cost gate is what enforces "need meter", no explicit check tag required. During
+# its cinematic super-freeze startup it owns Combat.Move.Startup and uses BlockAbilitiesWithTags to
+# lock out the opponent's normals (Light/Heavy/Block) for the freeze, then sweeps a high-damage hit
+# that applies GE_MeleeDamage. Blocked while in hitstun, blockstun, or staggered. Goes on a long
+# cooldown (GE_SpecialCooldown) so it cannot be chained even with meter to spare.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
+Name: GA_Special
+Tags:
+  AbilityTags:
+    - Ability.Type.Special
+  BlockAbilitiesWithTags:
+    - Ability.Type.Light
+    - Ability.Type.Heavy
+    - Ability.Type.Block
+  ActivationRequiredTags:
+    - State.Combat
+  ActivationBlockedTags:
+    - Combat.State.Hitstun
+    - Combat.State.Blockstun
+    - Combat.State.Staggered
+  ActivationOwnedTags:
+    - Combat.Move.Startup
+Cost: GE_SuperCost
+Cooldown: GE_SpecialCooldown
+Tasks:
+  - Type: WaitDelay
+    Params:
+      Duration: 0.5
+  - Type: WaitTargetData
+    Params:
+      TargetingMethod: MeleeSweep
+      MaxRange: 2.5
+      Hitzone: Hitzone.Mid
+  - Type: ApplyEffectToTarget
+    Params:
+      EffectClass: GE_MeleeDamage
+  - Type: WaitDelay
+    Params:
+      Duration: 0.4
+Metadata:
+  DisplayName: Special
+  Description: Spend a full super bar for a high-damage super move with an invulnerable super-freeze
+  Icon: ui/icons/special.png

--- a/genres/combat/entities/ability_special.yaml
+++ b/genres/combat/entities/ability_special.yaml
@@ -2,7 +2,8 @@
 # resource cost referenced by name like the racing pack's nitro cost) and so cannot activate on an
 # empty gauge - the cost gate is what enforces "need meter", no explicit check tag required. During
 # its cinematic super-freeze startup it owns Combat.Move.Startup and uses BlockAbilitiesWithTags to
-# lock out the opponent's normals (Light/Heavy/Block) for the freeze, then sweeps a high-damage hit
+# lock out the user's OWN normals (Light/Heavy/Block) for the freeze - committing the player to the
+# super animation (an owner-scoped self-lock, not anything applied to the opponent) - then sweeps a high-damage hit
 # that applies GE_MeleeDamage. Blocked while in hitstun, blockstun, or staggered. Goes on a long
 # cooldown (GE_SpecialCooldown) so it cannot be chained even with meter to spare.
 
@@ -42,5 +43,5 @@ Tasks:
       Duration: 0.4
 Metadata:
   DisplayName: Special
-  Description: Spend a full super bar for a high-damage super move with an invulnerable super-freeze
+  Description: Spend a full super bar for a high-damage super move; committed/uncancellable during the super-freeze
   Icon: ui/icons/special.png

--- a/genres/combat/entities/attribute_set.yaml
+++ b/genres/combat/entities/attribute_set.yaml
@@ -1,0 +1,128 @@
+# Fighter combat attribute set: survivability, the stagger (poise) and guard (block stamina)
+# meters, the super-meter resource, and the frame-data "feel" stats. Extends the core spec's
+# attribute model (no core attribute is redefined here). Base values describe a default
+# all-rounder fighter so the set is playable as shipped: 200 HP, a 100-point poise bar, an
+# empty 100-point super gauge, and 80 points of guard stamina.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/attribute_set.json
+Name: FighterCombatSet
+Attributes:
+  # --- Survivability (depleted by GE_MeleeDamage; reaching 0 Health is a KO) ---
+  - Name: MaxHealth
+    DefaultBaseValue: 200.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Maximum Health
+      UICategory: Survivability
+  - Name: Health
+    DefaultBaseValue: 200.0
+    Category: Resource
+    Clamping:
+      Min: 0
+      Max: MaxHealth
+    ReplicationMode: All
+    Metadata:
+      DisplayName: Health
+      Description: Hit points; reaching 0 is a KO. ExecCalc_MeleeResolution writes the per-hit loss
+      UICategory: Survivability
+
+  # --- Poise / stagger meter (the signature stagger system) ---
+  - Name: MaxPoise
+    DefaultBaseValue: 100.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Maximum Poise
+      UICategory: Stagger
+  - Name: Poise
+    DefaultBaseValue: 100.0
+    Category: Resource
+    Clamping:
+      Min: 0
+      Max: MaxPoise
+    ReplicationMode: All
+    Metadata:
+      DisplayName: Poise
+      Description: Stagger meter drained by poise damage; at 0 an engine threshold applies GE_Stagger
+      UICategory: Stagger
+
+  # --- Super meter (built by landing/taking hits, spent by GA_Special) ---
+  - Name: MaxSuper
+    DefaultBaseValue: 100.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Maximum Super
+      UICategory: Super
+  - Name: Super
+    DefaultBaseValue: 0.0
+    Category: Resource
+    Clamping:
+      Min: 0
+      Max: MaxSuper
+    ReplicationMode: All
+    Metadata:
+      DisplayName: Super Meter
+      Description: Gauge built by dealing and taking damage (ExecCalc_MeleeResolution); spent by GE_SuperCost
+      UICategory: Super
+
+  # --- Offense & defense (read by the melee-resolution calc) ---
+  - Name: AttackPower
+    DefaultBaseValue: 20.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Attack Power
+      Description: Base offensive stat; scaled by each attack's move multiplier before mitigation
+      UICategory: Offense
+  - Name: Defense
+    DefaultBaseValue: 10.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Defense
+      Description: Flat pre-mitigation damage reduction subtracted by ExecCalc_MeleeResolution
+      UICategory: Defense
+
+  # --- Guard / block stamina (depletes while blocking; empties into a guard break) ---
+  - Name: MaxGuardHealth
+    DefaultBaseValue: 80.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Maximum Guard Health
+      UICategory: Defense
+  - Name: GuardHealth
+    DefaultBaseValue: 80.0
+    Category: Resource
+    Clamping:
+      Min: 0
+      Max: MaxGuardHealth
+    ReplicationMode: All
+    Metadata:
+      DisplayName: Guard Health
+      Description: Block stamina; chipped by guard damage while blocking. At 0 the guard breaks (open to punish)
+      UICategory: Defense
+
+  # --- Movement ---
+  - Name: MoveSpeed
+    DefaultBaseValue: 500.0
+    Category: Statistic
+    Metadata:
+      DisplayName: Movement Speed
+      Description: Ground movement speed; slowed while blocking (GE_Blocking, Block channel)
+      UICategory: Movement
+
+  # --- Runtime state (written by the melee-resolution calc each time a hit lands) ---
+  - Name: IncomingDamage
+    DefaultBaseValue: 0.0
+    Category: Meta
+    Metadata:
+      DisplayName: Incoming Damage
+      Description: Transient per-hit damage magnitude handed to ExecCalc_MeleeResolution before mitigation
+      UICategory: Telemetry
+  - Name: EffectiveDamage
+    DefaultBaseValue: 0.0
+    Category: Meta
+    Metadata:
+      DisplayName: Effective Damage
+      Description: Output of ExecCalc_MeleeResolution after Defense and the Block channel; for telemetry/UI
+      UICategory: Telemetry
+Metadata:
+  DisplayName: Fighter Combat Set
+  Description: Survivability, poise/stagger and guard meters, the super gauge, and frame-data stats for a melee fighter

--- a/genres/combat/entities/effect_blocking.yaml
+++ b/genres/combat/entities/effect_blocking.yaml
@@ -1,0 +1,30 @@
+# Blocking: held while the block input is down (applied/removed by GA_Block). This is the genre's
+# signature defensive effect. It puts a Multiply of -0.6 in the Block channel on IncomingDamage:
+# IncomingDamage x (1 - 0.6) = x0.40, the guard damage reduction the melee-resolution calc reads
+# when it resolves a blocked hit. It also slows movement with a Multiply of -0.5 in the Block channel
+# (MoveSpeed x 0.50) - chip away at a defender's mobility for committing to guard - and grants
+# Combat.State.Blocking, the tag the calc keys its blocked-hit branch (guard damage, blockstun,
+# chip) off of. Because the reduction lives in its own named Block channel, additional defensive
+# layers (e.g. a parry or a guard upgrade in a separate channel) multiply across it cleanly, exactly
+# like the shooter's Aim and Attachments channels compose on Spread.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_Blocking
+DurationPolicy: Infinite
+Modifiers:
+  - Attribute: IncomingDamage
+    Operation: Multiply
+    Magnitude:
+      Type: ScalableFloat
+      Value: -0.6
+    Channel: Block
+  - Attribute: MoveSpeed
+    Operation: Multiply
+    Magnitude:
+      Type: ScalableFloat
+      Value: -0.5
+    Channel: Block
+GrantedTags:
+  - Combat.State.Blocking
+GameplayCues:
+  - GameplayCue.Combat.Guard

--- a/genres/combat/entities/effect_blockstun.yaml
+++ b/genres/combat/entities/effect_blockstun.yaml
@@ -1,0 +1,16 @@
+# Blockstun: the recovery state forced on a fighter who blocks a hit. HasDuration so it self-expires
+# after the block window; grants Combat.State.Blockstun, which blocks every action ability. Applied
+# to the target alongside GE_MeleeDamage on a blocked hit. Blockstun is shorter than the attacker's
+# own recovery on a well-spaced attack, which is what makes some blocked strings safe and others
+# punishable. The duration is the move's blockstun frame count expressed in seconds.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_Blockstun
+DurationPolicy: HasDuration
+Duration:
+  Type: ScalableFloat
+  Value: 0.25
+GrantedTags:
+  - Combat.State.Blockstun
+GameplayCues:
+  - GameplayCue.Combat.Blockstun

--- a/genres/combat/entities/effect_hitstun.yaml
+++ b/genres/combat/entities/effect_hitstun.yaml
@@ -1,0 +1,15 @@
+# Hitstun: the recovery state forced on a fighter who is cleanly hit. HasDuration so it self-expires
+# after the stun window; grants Combat.State.Hitstun, which blocks every action ability
+# (their ActivationBlockedTags list it). Applied to the target alongside GE_MeleeDamage on a clean
+# (unblocked) hit. The duration is the move's hitstun frame count expressed in seconds.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_Hitstun
+DurationPolicy: HasDuration
+Duration:
+  Type: ScalableFloat
+  Value: 0.4
+GrantedTags:
+  - Combat.State.Hitstun
+GameplayCues:
+  - GameplayCue.Combat.Hitstun

--- a/genres/combat/entities/effect_melee_damage.yaml
+++ b/genres/combat/entities/effect_melee_damage.yaml
@@ -1,0 +1,17 @@
+# The melee hit payload applied by GA_LightAttack / GA_HeavyAttack / GA_Special to the target.
+# Combat damage is not a single subtraction: it couples the source's AttackPower (scaled by the
+# move's multiplier, supplied as IncomingDamage) with the target's flat Defense, the Block channel
+# damage reduction when the target owns Combat.State.Blocking, plus poise damage and guard damage,
+# and it feeds the super gauge of both fighters. That can't be a static modifier, so it delegates to
+# a custom Execution (ExecCalc_MeleeResolution). The calc honors Team.Friendly targets (skips
+# friendly fire) and writes EffectiveDamage (Meta) for telemetry/UI. This is the combat analogue of
+# the shooter's hit-resolution calc and the racing traction calc - the seam where the genre's
+# signature math plugs into UGAS.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_MeleeDamage
+DurationPolicy: Instant
+Executions:
+  - CalculatorClass: ExecCalc_MeleeResolution
+GameplayCues:
+  - GameplayCue.Combat.Impact

--- a/genres/combat/entities/effect_stagger.yaml
+++ b/genres/combat/entities/effect_stagger.yaml
@@ -1,0 +1,17 @@
+# Stagger: the punish window opened when a fighter's Poise meter is fully drained. HasDuration so it
+# self-expires after the stagger window; grants Combat.State.Staggered, which blocks every action
+# ability and leaves the fighter open to a guaranteed punish. This effect is NOT applied by an
+# ability - it is applied by the engine when the OnAttributeChanged threshold on Poise (Poise == 0)
+# fires (core spec section 5.6), keeping with the rule that states are granted by Effects, never
+# written directly. The stagger window is long enough to land a full combo.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_effect.json
+Name: GE_Stagger
+DurationPolicy: HasDuration
+Duration:
+  Type: ScalableFloat
+  Value: 1.5
+GrantedTags:
+  - Combat.State.Staggered
+GameplayCues:
+  - GameplayCue.Combat.Stagger

--- a/genres/combat/entities/gameplay_controller.yaml
+++ b/genres/combat/entities/gameplay_controller.yaml
@@ -1,0 +1,87 @@
+# Worked example: a fighter mid-block, the instant after eating one heavy hit on guard.
+# GE_Blocking is the only active effect; its Block-channel modifiers slow the holder and feed the
+# damage reduction the melee-resolution calc reads. CurrentValue columns show the result.
+#   The blocked heavy hit (attacker AttackPower 20 x heavy move multiplier 2.5 = 50 raw):
+#     IncomingDamage:  50 raw x Block(1 - 0.6 = 0.40)                       = 20.0  (post-block)
+#     EffectiveDamage: max(0, 20 post-block - Defense 10)                   = 10.0
+#     Health:          200 - 10 (EffectiveDamage)                          = 190.0
+#     GuardHealth:     80 - 30 (heavy guard damage, chipped while blocking) = 50.0
+#     Poise:           100 - 10 (heavy block-poise chip)                    = 90.0
+#     Super:           0 + 8 (meter gained for taking the hit)             = 8.0
+#   Block-channel movement penalty (active while guard is held):
+#     MoveSpeed:       500 x Block(1 - 0.5 = 0.50)                          = 250.0
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_controller.json
+OwnerActor:
+  ActorID: Fighter_Brawler_01
+  ActorType: PlayerCharacter
+AttributeSets:
+  - Name: FighterCombatSet
+    Attributes:
+      - Name: MaxHealth
+        BaseValue: 200.0
+        CurrentValue: 200.0
+      - Name: Health
+        BaseValue: 200.0
+        CurrentValue: 190.0
+      - Name: MaxPoise
+        BaseValue: 100.0
+        CurrentValue: 100.0
+      - Name: Poise
+        BaseValue: 100.0
+        CurrentValue: 90.0
+      - Name: MaxSuper
+        BaseValue: 100.0
+        CurrentValue: 100.0
+      - Name: Super
+        BaseValue: 0.0
+        CurrentValue: 8.0
+      - Name: AttackPower
+        BaseValue: 20.0
+        CurrentValue: 20.0
+      - Name: Defense
+        BaseValue: 10.0
+        CurrentValue: 10.0
+      - Name: MaxGuardHealth
+        BaseValue: 80.0
+        CurrentValue: 80.0
+      - Name: GuardHealth
+        BaseValue: 80.0
+        CurrentValue: 50.0
+      - Name: MoveSpeed
+        BaseValue: 500.0
+        CurrentValue: 250.0
+      - Name: IncomingDamage
+        BaseValue: 0.0
+        CurrentValue: 20.0
+      - Name: EffectiveDamage
+        BaseValue: 0.0
+        CurrentValue: 10.0
+GrantedAbilities:
+  - AbilityClass: GA_LightAttack
+    Level: 1
+    InputID: LightAttack
+  - AbilityClass: GA_HeavyAttack
+    Level: 1
+    InputID: HeavyAttack
+  - AbilityClass: GA_Block
+    Level: 1
+    InputID: Block
+  - AbilityClass: GA_Special
+    Level: 1
+    InputID: Special
+ActiveEffects:
+  - Handle: eff-blocking
+    EffectClass: GE_Blocking
+    Duration: -1
+OwnedTags:
+  - State.Alive
+  - State.Combat
+  - Team.Friendly
+  - Combat.State.Blocking
+ReplicationMode: Mixed
+bIsActive: true
+Metadata:
+  DisplayName: Brawler (blocking, just ate a heavy)
+  Description: Worked-example fighter showing the Block-channel damage reduction, guard/poise drain, and movement penalty
+  DebugCategory: combat-pack-example

--- a/genres/combat/entities/input_action_set_brawl.yaml
+++ b/genres/combat/entities/input_action_set_brawl.yaml
@@ -1,0 +1,29 @@
+# Brawl action set: the default input context for a fighter in a match. Groups the five combat and
+# movement actions into a single set that is active whenever the fighter is alive and in combat, and
+# not in a cutscene. Input buffering is enabled with a 0.15 s window (max 3 queued events) so that
+# fast cancel strings - light buffered into heavy, special buffered out of a launcher - register on
+# the frame they become legal rather than being dropped, the responsiveness fighting games demand.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action_set.json
+Name: Brawl
+Actions:
+  - LightAttack
+  - HeavyAttack
+  - Block
+  - Special
+  - Move
+Priority: 0
+ActivationTags:
+  RequiredTags:
+    - State.Alive
+    - State.Combat
+  BlockedTags:
+    - State.Cutscene
+Exclusive: false
+InputBuffer:
+  Enabled: true
+  BufferWindow: 0.15
+  MaxBufferSize: 3
+Metadata:
+  DisplayName: Brawl
+  Description: Default fighting input context covering attacks, blocking, the special, and movement

--- a/genres/combat/entities/input_actions.yaml
+++ b/genres/combat/entities/input_actions.yaml
@@ -1,0 +1,78 @@
+# Combat genre input actions. Each document defines a single action that an ability listens for via
+# its InputID. Actions are grouped into the Brawl action set (see input_action_set_brawl.yaml) and
+# bound to hardware in the input mappings. LightAttack / HeavyAttack / Special are press triggers;
+# Block is held (its ability waits on the matching release); Move is a continuous 2D vector.
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: LightAttack
+ValueType: Digital
+TriggerBehavior: OnPressed
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Light
+Metadata:
+  DisplayName: Light Attack
+  Description: Fast jab - the combo starter
+  Icon: ui/icons/light_attack.png
+  Category: Combat
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: HeavyAttack
+ValueType: Digital
+TriggerBehavior: OnPressed
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Heavy
+Metadata:
+  DisplayName: Heavy Attack
+  Description: Slow, heavy blow that cancels light-attack recovery
+  Icon: ui/icons/heavy_attack.png
+  Category: Combat
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Block
+ValueType: Digital
+TriggerBehavior: WhileHeld
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Block
+Metadata:
+  DisplayName: Block
+  Description: Hold to guard against incoming attacks
+  Icon: ui/icons/block.png
+  Category: Combat
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Special
+ValueType: Digital
+TriggerBehavior: OnPressed
+ConsumeInput: true
+Tags:
+  ActionTags:
+    - Ability.Type.Special
+Metadata:
+  DisplayName: Special
+  Description: Spend a full super bar for a super move
+  Icon: ui/icons/special.png
+  Category: Combat
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_action.json
+Name: Move
+ValueType: Axis2D
+TriggerBehavior: WhileHeld
+ConsumeInput: true
+Tags:
+  ActionTags: []
+Metadata:
+  DisplayName: Move
+  Description: Walk, dash, and crouch direction (crouch enables low blocking)
+  Icon: ui/icons/move.png
+  Category: Movement

--- a/genres/combat/entities/input_mapping_brawl_gamepad.yaml
+++ b/genres/combat/entities/input_mapping_brawl_gamepad.yaml
@@ -1,0 +1,44 @@
+# Console gamepad mapping for the Brawl action set - the canonical fighting-game controller layout.
+# Light and heavy attacks sit on the bottom and right face buttons; the special is on the right
+# shoulder for a clean two-button-plus-meter input; block holds on the left trigger (with a press
+# threshold so a half-pull does not drop guard). The left stick passes through a radial dead zone
+# and radial scaling so diagonal walk/crouch inputs read consistently.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_mapping.json
+ActionSet: Brawl
+Platform: Console
+Bindings:
+  - Action: LightAttack
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.FaceBottom
+
+  - Action: HeavyAttack
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.FaceRight
+
+  - Action: Special
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.RightShoulder
+
+  - Action: Block
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.LeftTrigger
+    Modifiers:
+      - TriggerThreshold
+
+  - Action: Move
+    Inputs:
+      - Device: Gamepad
+        Input: Gamepad.LeftStick.X
+      - Device: Gamepad
+        Input: Gamepad.LeftStick.Y
+    Modifiers:
+      - StickDeadzone
+      - RadialScaling
+Metadata:
+  DisplayName: Brawl - Gamepad
+  Description: Console gamepad bindings for the fighting action set (two attacks, special, hold-block, stick movement)

--- a/genres/combat/entities/input_modifiers.yaml
+++ b/genres/combat/entities/input_modifiers.yaml
@@ -1,0 +1,38 @@
+# Reusable input modifiers for the combat genre. Referenced by name in the input mappings.
+# StickDeadzone is player-configurable; the others are tuning knobs owned by the designer. All
+# modifiers sit in the per-binding modifier pipeline and run in the order listed on each binding.
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_modifier.json
+Name: StickDeadzone
+Type: DeadZone
+Params:
+  DeadZoneShape: Radial
+  InnerThreshold: 0.2
+  OuterThreshold: 0.9
+UserConfigurable: true
+Metadata:
+  DisplayName: Stick Dead Zone
+  Description: Radial dead zone for the walk/crouch stick - ignores drift below 20% and saturates above 90%
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_modifier.json
+Name: RadialScaling
+Type: RadialScaling
+Params:
+  MaxRadius: 1.0
+UserConfigurable: false
+Metadata:
+  DisplayName: Radial Scaling
+  Description: Normalizes stick input to a maximum radius of 1.0 for consistent diagonal walk/crouch
+
+---
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/input_modifier.json
+Name: TriggerThreshold
+Type: TriggerThreshold
+Params:
+  PressThreshold: 0.5
+UserConfigurable: false
+Metadata:
+  DisplayName: Trigger Threshold
+  Description: Analog trigger press threshold for the block trigger - values below 0.5 are treated as released

--- a/genres/combat/entities/tag_registry.yaml
+++ b/genres/combat/entities/tag_registry.yaml
@@ -41,7 +41,7 @@ Tags:
     Description: Defensive guard ability
     AllowMultiple: false
   - Tag: Ability.Type.Special
-    Description: Super-meter spender with invulnerable super-freeze startup
+    Description: Super-meter spender with a committed/uncancellable super-freeze startup
     AllowMultiple: false
 
   # --- Hitzones (where on the body a hit lands; drives high/mid/low guard rules) ---

--- a/genres/combat/entities/tag_registry.yaml
+++ b/genres/combat/entities/tag_registry.yaml
@@ -1,0 +1,64 @@
+# Combat genre tag taxonomy. ADDITIVE: introduces genre-specific tags only.
+# It does not redefine the core lifecycle tags (State.Alive / State.Combat / State.Dead) -
+# those are referenced by the pack's entities, not declared here. Frame-data states and the
+# stagger/block states are all GRANTED BY EFFECTS; abilities only gate on them.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_tag.json
+Tags:
+  # --- Combat states (granted by Effects; the frame-data + stagger/guard state machine) ---
+  - Tag: Combat.State.Hitstun
+    Description: Recovering from a clean hit; granted by GE_Hitstun, blocks all actions for the stun window
+    AllowMultiple: false
+  - Tag: Combat.State.Blockstun
+    Description: Recovering from a blocked hit; granted by GE_Blockstun, blocks all actions for the block window
+    AllowMultiple: false
+  - Tag: Combat.State.Blocking
+    Description: Actively guarding; granted by GE_Blocking while the block input is held
+    AllowMultiple: false
+  - Tag: Combat.State.Staggered
+    Description: Poise broken; granted by GE_Stagger when Poise hits 0, leaving the fighter open to punish
+    AllowMultiple: false
+
+  # --- Move frame phases (the startup / active / recovery windows of an attack) ---
+  - Tag: Combat.Move.Startup
+    Description: Wind-up phase before the hitbox is live; the attack is committed but not yet threatening
+    AllowMultiple: false
+  - Tag: Combat.Move.Active
+    Description: Hitbox-live phase; contact during this window applies the move's GE_MeleeDamage
+    AllowMultiple: false
+  - Tag: Combat.Move.Recovery
+    Description: Cool-down phase after the hitbox closes; the cancel window a faster move can interrupt
+    AllowMultiple: false
+
+  # --- Ability classification (used by cancel/block tag queries between moves) ---
+  - Tag: Ability.Type.Light
+    Description: Fast, low-damage normal; the combo starter
+    AllowMultiple: false
+  - Tag: Ability.Type.Heavy
+    Description: Slow, high-damage normal; cancels a light attack's recovery
+    AllowMultiple: false
+  - Tag: Ability.Type.Block
+    Description: Defensive guard ability
+    AllowMultiple: false
+  - Tag: Ability.Type.Special
+    Description: Super-meter spender with invulnerable super-freeze startup
+    AllowMultiple: false
+
+  # --- Hitzones (where on the body a hit lands; drives high/mid/low guard rules) ---
+  - Tag: Hitzone.High
+    Description: Overhead hit; must be blocked standing
+    AllowMultiple: false
+  - Tag: Hitzone.Mid
+    Description: Mid-level hit; blockable standing or crouching
+    AllowMultiple: false
+  - Tag: Hitzone.Low
+    Description: Low hit; must be blocked crouching
+    AllowMultiple: false
+
+  # --- Teams (used to skip friendly fire in the melee-resolution calc) ---
+  - Tag: Team.Friendly
+    Description: Same side as the source; the melee-resolution calc skips friendly fire
+    AllowMultiple: false
+  - Tag: Team.Hostile
+    Description: Opposing side; a valid melee target
+    AllowMultiple: false

--- a/genres/combat/spec.adoc
+++ b/genres/combat/spec.adoc
@@ -1,0 +1,234 @@
+= UGAS Genre Pack: Combat
+Mickael Bonfill <jbltx>
+:revnumber: 1.0.0-draft.1
+:ugas-version: v1.0.0-draft.1
+:doctype: book
+:toc: left
+:toc-title: Table of Contents
+:toclevels: 4
+:stem: latexmath
+:source-highlighter: highlight.js
+:icons: font
+:sectanchors:
+:sectlinks:
+:docinfo: shared
+
+[[overview]]
+== Overview
+
+This genre pack targets *skill-based melee combat* — fighters, brawlers, and hack-and-slash in the
+Street Fighter / Tekken / God of War mould: a character defined by *frame-data states* (hitstun and
+blockstun), a *poise → stagger* system that opens punish windows, a *guard / block damage channel*
+that trades chip damage and mobility for safety, a *super meter* spent on specials, and *combo
+cancels* expressed through ability block/cancel tags. Its core loop is the melee exchange — strike,
+block, cancel, stagger, punish — rather than the projectile-and-ammo loop of a shooter.
+
+The core specification ships no dedicated fighting case study, so this pack is designed from first
+principles. It still leans entirely on core constructs: the modifier `Channel` mechanism
+(link:../../SPEC.adoc[core spec] §5.3) for the guard damage reduction, a custom `Execution`
+(§9.5) for the multi-attribute hit resolution, `ActivationOwnedTags` / `CancelAbilitiesWithTags` /
+`BlockAbilitiesWithTags` (§8.1) for the cancel and super-freeze rules, and effect-granted tags
+(§7.5, §9.7) for the entire frame-data and stagger state machine.
+
+The 1v1 duelist is the concrete seed, but the same pieces generalize across the wider
+link:../taxonomy.html[*Combat* family] — beat 'em up, brawler, hack-and-slash — which layer
+crowd targeting, juggles, and arenas on top of this strike-block-stagger core. Where the
+link:../shooter/index.html[Shooter pack] resolves hits at range with ammo, falloff, and hitzone
+multipliers, this pack resolves them in melee with frame phases, a guard meter, and a stagger meter
+— no projectiles, no reloads.
+
+[[relationship-to-core-spec]]
+== Relationship to the core specification
+
+This document is *additive*. It defines genre-specific Attributes, Tags, Abilities, and
+Effects on top of the core Universal Gameplay Ability System specification.
+
+* It MUST NOT redefine, override, or contradict any concept in the core spec.
+* All entities in `entities/` validate against the same `schemas/*.json` as the core.
+* It *reuses* the core lifecycle tags (`State.Alive`, `State.Combat`, `State.Dead`) by reference,
+  and adds combat-specific states (`Combat.State.Hitstun`, `Combat.State.Staggered`, …).
+* Combat state is mutated *only through Effects* (core spec §7.5) — abilities gate on tags and apply
+  Effects, never writing tags directly — and the guard damage reduction is the core modifier
+  `Channel` mechanism (§5.3), not a new construct.
+
+[[genre-attributes]]
+== Genre Attributes
+
+Defined in `entities/attribute_set.yaml` as the `FighterCombatSet` set. The base values describe a
+default all-rounder fighter, so the set is playable as shipped.
+
+[cols="1,1,3",options="header"]
+|===
+| Attribute | Category | Role
+
+| `MaxHealth` / `Health` | Statistic / Resource | `Health` is clamped to `[0, MaxHealth]`; reaching 0 is a KO. `ExecCalc_MeleeResolution` writes the per-hit loss.
+| `MaxPoise` / `Poise` | Statistic / Resource | The stagger meter, clamped to `[0, MaxPoise]`; drained by poise damage. At 0, an engine threshold applies `GE_Stagger`.
+| `MaxSuper` / `Super` | Statistic / Resource | The super gauge, clamped to `[0, MaxSuper]`; built by dealing and taking hits, spent by `GE_SuperCost`.
+| `AttackPower` | Statistic | Base offense; scaled by each move's multiplier before mitigation.
+| `Defense` | Statistic | Flat pre-mitigation damage reduction subtracted by the hit-resolution calc.
+| `MaxGuardHealth` / `GuardHealth` | Statistic / Resource | Block stamina, clamped to `[0, MaxGuardHealth]`; chipped by guard damage while blocking. At 0 the guard breaks.
+| `MoveSpeed` | Statistic | Ground movement speed; slowed while blocking (the `Block` channel).
+| `IncomingDamage` | Meta | Transient per-hit magnitude handed to the calc before mitigation; the target of the `Block` channel reduction.
+| `EffectiveDamage` | Meta | Output of the hit-resolution calc after `Defense` and the `Block` channel; for telemetry/UI.
+|===
+
+[[genre-melee-exchange]]
+== The melee exchange (the core combat mechanic)
+
+A fighting game lives or dies on the *exchange*: who can strike, who must block, and who gets
+punished. In UGAS that exchange is a small set of tag-gated abilities, a guard damage channel, and
+two depletable meters.
+
+=== Frame-data states gate every action
+
+Real fighting games are governed by _frame data_: after a move connects, the loser spends a fixed
+number of frames unable to act. UGAS models those windows as *effect-granted states*:
+
+* A clean hit applies `GE_Hitstun` (`entities/effect_hitstun.yaml`), which grants
+  `Combat.State.Hitstun` for the stun window.
+* A blocked hit applies `GE_Blockstun` (`entities/effect_blockstun.yaml`), which grants
+  `Combat.State.Blockstun`.
+
+Both states appear in every action ability's `ActivationBlockedTags`, so a stunned fighter simply
+cannot act until the timed effect expires — no explicit timer lives in the ability. Whether the
+defender's blockstun expires before the attacker's own recovery is what makes a blocked string
+_safe_ or _punishable_.
+
+=== Cancel windows via the frame-phase tags
+
+Each attack walks three phases — `Combat.Move.Startup` → `Combat.Move.Active` →
+`Combat.Move.Recovery` — owned through `ActivationOwnedTags`. The combo system is then pure tag
+logic:
+
+* `GA_LightAttack` owns `Combat.Move.Recovery` during its tail.
+* `GA_HeavyAttack` lists `Ability.Type.Light` in its `CancelAbilitiesWithTags`, so a heavy buffered
+  during the light's recovery *cancels* it — the canonical light → heavy combo cancel, expressed
+  with tags alone.
+* `GA_Special` lists the normals in its `BlockAbilitiesWithTags`, locking the opponent out of
+  Light/Heavy/Block during its cinematic super-freeze startup.
+
+=== The guard damage channel
+
+`GA_Block` (`entities/ability_block.yaml`) holds `GE_Blocking` (`entities/effect_blocking.yaml`)
+while the block input is down — the same hold-then-`WaitInputRelease` shape as the shooter's
+aim-down-sights. `GE_Blocking` is the genre's signature effect. Modifiers stack through *named
+channels* — additive *within* a channel, multiplicative *across* channels (§5.3) — so `GE_Blocking`
+puts a single `Multiply` in a `Block` channel:
+
+* On `IncomingDamage`: a `Multiply` of latexmath:[-0.6] → factor latexmath:[1 - 0.6 = 0.40]. The
+  hit-resolution calc reads the reduced magnitude on a blocked hit.
+* On `MoveSpeed`: a `Multiply` of latexmath:[-0.5] → factor latexmath:[1 - 0.5 = 0.50]. Committing
+  to guard costs mobility.
+
+Because the reduction lives in its own named channel, additional defensive layers (a parry, a guard
+upgrade) authored in a *different* channel multiply across it cleanly — exactly how the shooter's
+`Aim` and `Attachments` channels compose on `Spread`.
+
+=== Poise drains to a stagger
+
+`Poise` is a depletable stat: every hit (blocked or not) deals poise damage. When `Poise` reaches
+`0`, the engine's `OnAttributeChanged` threshold (§5.6) applies `GE_Stagger`
+(`entities/effect_stagger.yaml`), which grants `Combat.State.Staggered` for a long window — a
+guaranteed punish. The threshold keeps the rule that *states are granted by Effects, never written
+directly*.
+
+=== Worked example (`entities/gameplay_controller.yaml`)
+
+A fighter mid-block eats one heavy hit. The attacker's `AttackPower` (latexmath:[20]) scaled by the
+heavy move multiplier (latexmath:[2.5]) is the raw hit, handed to the calc as `IncomingDamage`. The
+defender owns `Combat.State.Blocking`, so the `Block` channel and `Defense` both apply:
+
+[stem]
+++++
+\text{IncomingDamage}_{\text{post-block}} = 50 \times \underbrace{(1 - 0.6)}_{\text{Block channel}} = 20.0
+++++
+
+[stem]
+++++
+\text{EffectiveDamage} = \max\!\left(0,\; 20 - \underbrace{10}_{\text{Defense}}\right) = 10.0
+++++
+
+The same blocked hit drains the two meters and feeds the gauge, and holding guard slows the fighter
+through the `Block` channel:
+
+* `Health`: latexmath:[200 - 10 = 190] (the `EffectiveDamage`)
+* `GuardHealth`: latexmath:[80 - 30 = 50] (heavy guard damage, chipped while blocking)
+* `Poise`: latexmath:[100 - 10 = 90] (the heavy's block-poise chip)
+* `Super`: latexmath:[0 + 8 = 8] (meter gained for taking the hit)
+* `MoveSpeed`: latexmath:[500 \times (1 - 0.5) = 250] (the `Block` channel)
+
+These are exactly the `CurrentValue` entries recorded for the example fighter. Had the hit landed
+*unblocked*, the `Block` channel would be absent (factor latexmath:[1.0]), the calc would apply
+`GE_Hitstun` instead of `GE_Blockstun`, and poise damage would be far higher — the difference
+between a chipped guard and a broken one.
+
+=== Hit resolution via ExecutionCalculation
+
+Melee damage is not a single subtraction: it couples the source's `AttackPower` (× the move
+multiplier), the target's flat `Defense`, the `Block` channel reduction, poise damage, guard damage,
+and the super gain for *both* fighters. That is inherently multi-attribute and cross-actor, so
+`GE_MeleeDamage` (`entities/effect_melee_damage.yaml`) delegates to a custom `Execution` (§9.5),
+`ExecCalc_MeleeResolution`, which honors `Team.Friendly` targets (skips friendly fire) and writes
+`EffectiveDamage` (a `Meta` attribute) for telemetry and UI. This is the combat analogue of the
+shooter's hit-resolution calc and the racing traction calc — the seam where the genre's signature
+math plugs into UGAS. An adopter who prefers a declarative poise-damage rule can express it as an
+`AttributeBased` magnitude (§9.4.2) keyed on the source's `AttackPower`
+(latexmath:[(\text{AttackPower} + \text{PreAdd}) \times \text{Coefficient} + \text{PostAdd}]); the
+worked numbers above keep poise damage inside the calc for a single source of truth.
+
+[[genre-tags]]
+== Genre Tags
+
+Defined in `entities/tag_registry.yaml` (additive only):
+
+* *Combat states* — `Combat.State.Hitstun`, `Combat.State.Blockstun`, `Combat.State.Blocking`,
+  `Combat.State.Staggered` (all granted by Effects).
+* *Move frame phases* — `Combat.Move.Startup`, `Combat.Move.Active`, `Combat.Move.Recovery`.
+* *Ability types* — `Ability.Type.Light|Heavy|Block|Special` (the keys for cancel/block queries).
+* *Hitzones* — `Hitzone.High|Mid|Low` (high/mid/low guard rules).
+* *Teams* — `Team.Friendly|Hostile` (friendly-fire skip in the calc).
+
+[[genre-abilities]]
+== Genre Abilities
+
+* `entities/ability_light_attack.yaml` — `GA_LightAttack`: fast startup, short recovery; owns
+  `Combat.Move.Recovery` so a heavy can cancel it.
+* `entities/ability_heavy_attack.yaml` — `GA_HeavyAttack`: slow, high-damage; its
+  `CancelAbilitiesWithTags` cancels the light's recovery.
+* `entities/ability_block.yaml` — `GA_Block`: holds `GE_Blocking` for the `Block`-channel reduction
+  at the cost of movement; ends on input release.
+* `entities/ability_special.yaml` — `GA_Special`: costs a full bar (`Cost: GE_SuperCost`) and uses
+  `BlockAbilitiesWithTags` to lock the opponent out during super-freeze; on `GE_SpecialCooldown`.
+
+[[genre-effects]]
+== Genre Effects
+
+* `entities/effect_melee_damage.yaml` — `GE_MeleeDamage`: instant; runs `ExecCalc_MeleeResolution`
+  to resolve a hit (damage, poise, guard, super) and write `EffectiveDamage`.
+* `entities/effect_hitstun.yaml` — `GE_Hitstun`: `HasDuration`; grants `Combat.State.Hitstun`,
+  blocking all actions.
+* `entities/effect_blockstun.yaml` — `GE_Blockstun`: `HasDuration`; grants `Combat.State.Blockstun`,
+  blocking all actions (shorter than hitstun).
+* `entities/effect_blocking.yaml` — `GE_Blocking`: infinite-while-held; `Block`-channel `Multiply`
+  on `IncomingDamage` and `MoveSpeed`; grants `Combat.State.Blocking`.
+* `entities/effect_stagger.yaml` — `GE_Stagger`: `HasDuration`; grants `Combat.State.Staggered`,
+  applied by the engine's `Poise == 0` threshold.
+
+The trivial cost and cooldown effects the abilities reference — `GE_SuperCost` (subtracts `Super`),
+`GE_LightAttackCooldown`, `GE_HeavyAttackCooldown`, `GE_SpecialCooldown` — are flat resource costs
+and cooldown tags, referenced by name rather than shipped as files, the same convention the Racing
+and Shooter packs use for their nitro/fire cost and cooldown effects.
+
+[[using-this-pack]]
+== Using this pack
+
+. Copy `genres/combat/` into your project (or load `entities/` directly via the
+  `ugas-schema-author` skill).
+. Tune the fighter base values in `FighterCombatSet` first — `MaxHealth`, the `Poise`/`GuardHealth`
+  meters, and `AttackPower`/`Defense` carry the match pacing — then add moves as new Abilities +
+  `GE_MeleeDamage` payloads and new defensive layers as effects in their own `Channel`.
+. Implement the one `ExecCalc_MeleeResolution` hook in your engine (the only seam: damage, poise,
+  guard, and super math); everything else is data.
+. Author new states as `Combat.State.*` tags granted by Effects (never mutate tags directly), and
+  drive stagger from the engine `Poise == 0` threshold applying `GE_Stagger`.
+. Validate with `python scripts/validate_schema_examples.py` before committing.

--- a/genres/combat/spec.adoc
+++ b/genres/combat/spec.adoc
@@ -96,16 +96,18 @@ _safe_ or _punishable_.
 
 === Cancel windows via the frame-phase tags
 
-Each attack walks three phases — `Combat.Move.Startup` → `Combat.Move.Active` →
-`Combat.Move.Recovery` — owned through `ActivationOwnedTags`. The combo system is then pure tag
+`Combat.Move.Startup` → `Combat.Move.Active` → `Combat.Move.Recovery` is the illustrative phase
+vocabulary the engine sets on a fighter as a move plays out; individual abilities own only the
+phase windows they actually need through `ActivationOwnedTags`. The combo system is then pure tag
 logic:
 
 * `GA_LightAttack` owns `Combat.Move.Recovery` during its tail.
 * `GA_HeavyAttack` lists `Ability.Type.Light` in its `CancelAbilitiesWithTags`, so a heavy buffered
   during the light's recovery *cancels* it — the canonical light → heavy combo cancel, expressed
   with tags alone.
-* `GA_Special` lists the normals in its `BlockAbilitiesWithTags`, locking the opponent out of
-  Light/Heavy/Block during its cinematic super-freeze startup.
+* `GA_Special` lists the normals in its `BlockAbilitiesWithTags`, locking the super-user out of
+  *their own* Light/Heavy/Block while the special is active — `BlockAbilitiesWithTags` is
+  owner-scoped, so this commits the player to the super animation rather than touching the opponent.
 
 === The guard damage channel
 
@@ -198,7 +200,8 @@ Defined in `entities/tag_registry.yaml` (additive only):
 * `entities/ability_block.yaml` — `GA_Block`: holds `GE_Blocking` for the `Block`-channel reduction
   at the cost of movement; ends on input release.
 * `entities/ability_special.yaml` — `GA_Special`: costs a full bar (`Cost: GE_SuperCost`) and uses
-  `BlockAbilitiesWithTags` to lock the opponent out during super-freeze; on `GE_SpecialCooldown`.
+  `BlockAbilitiesWithTags` to lock the user out of *their own* normals during super-freeze (an
+  owner-scoped self-lock that commits the player to the super); on `GE_SpecialCooldown`.
 
 [[genre-effects]]
 == Genre Effects

--- a/genres/index.adoc
+++ b/genres/index.adoc
@@ -63,6 +63,10 @@ schema-conformant template files you can copy and extend.
 | link:shooter/index.html[*Shooter*]
 | First/third-person gunplay — ammo economy and hit resolution
 | `shooter/entities/`
+
+| link:combat/index.html[*Combat*]
+| Melee fighting/brawler — frame-data states, poise→stagger, guard channel
+| `combat/entities/`
 |===
 
 [[using-a-pack]]


### PR DESCRIPTION
## What this adds

An additive **Combat** genre pack at `genres/combat/` for skill-based melee dueling (fighting / brawler / hack-and-slash), built entirely on existing core constructs — no core-spec change. It mirrors the structure, depth, and tone of the gold-standard Racing and Shooter packs and is deliberately distinct from the Shooter pack: melee instead of projectiles, frame phases instead of an ammo economy, a guard meter and a stagger meter instead of reloads and range falloff.

- **`FighterCombatSet`** (`entities/attribute_set.yaml`) — `MaxHealth`/`Health`, the `MaxPoise`/`Poise` stagger meter, the `MaxSuper`/`Super` gauge, `AttackPower`, `Defense`, the `MaxGuardHealth`/`GuardHealth` block-stamina meter, `MoveSpeed`, and `IncomingDamage`/`EffectiveDamage` meta. Base values make a default all-rounder playable as shipped (200 HP, 100-point poise/super meters, 80-point guard).
- **Tag taxonomy** (`entities/tag_registry.yaml`) — `Combat.State.Hitstun|Blockstun|Blocking|Staggered`, `Combat.Move.Startup|Active|Recovery`, `Ability.Type.Light|Heavy|Block|Special`, `Hitzone.High|Mid|Low`, `Team.Friendly|Hostile`. Core lifecycle tags (`State.Alive|Combat|Dead`) are reused by reference, never re-declared.
- **Abilities** — `GA_LightAttack`, `GA_HeavyAttack`, `GA_Block` (hold → `GE_Blocking`, `WaitInputRelease`), `GA_Special` (`Cost: GE_SuperCost`).
- **Effects** — `GE_MeleeDamage` (instant; delegates to the Execution), `GE_Hitstun`/`GE_Blockstun` (HasDuration states that block all actions), `GE_Blocking` (infinite-while-held; Block-channel reduction + movement slow), `GE_Stagger` (HasDuration; applied by the engine `Poise == 0` threshold). Trivial cost/cooldown effects (`GE_SuperCost`, `GE_*Cooldown`) are referenced by name, the same convention as the Racing/Shooter packs.
- **Input layer** — `input_actions.yaml` (Light/Heavy/Block/Special/Move), the `Brawl` action set with combo-friendly buffering, a gamepad mapping, and reusable input modifiers.

## Signature mechanic — the melee exchange

A small set of tag-gated abilities, a guard damage channel, and two depletable meters:

- **Frame-data states.** A clean hit applies `GE_Hitstun`; a blocked hit applies `GE_Blockstun`. Both states sit in every action's `ActivationBlockedTags`, so a stunned fighter cannot act until the timed effect expires. Whether blockstun expires before the attacker's recovery is what makes a blocked string safe or punishable.
- **Combo cancels via tags.** Each attack walks `Combat.Move.Startup → Active → Recovery` (`ActivationOwnedTags`). `GA_HeavyAttack`'s `CancelAbilitiesWithTags: [Ability.Type.Light]` cancels a light attack's recovery (the light→heavy cancel); `GA_Special`'s `BlockAbilitiesWithTags` locks the opponent out of normals during its super-freeze startup.
- **Guard damage channel.** `GE_Blocking` puts a single `Multiply` in a named `Block` channel on `IncomingDamage` (−0.6 → ×0.40) and `MoveSpeed` (−0.5 → ×0.50). Additional defensive layers authored in a different channel multiply across it cleanly — exactly how the Shooter's `Aim` × `Attachments` channels compose on `Spread` (core §5.3).
- **Poise → stagger.** Every hit deals poise damage; at `Poise == 0` the engine `OnAttributeChanged` threshold (core §5.6) applies `GE_Stagger`, granting `Combat.State.Staggered` — keeping the rule that states are granted by Effects, never written directly.

## Worked-example math (`entities/gameplay_controller.yaml`)

A fighter mid-block eats one heavy hit. Attacker `AttackPower` 20 × heavy multiplier 2.5 = 50 raw, handed to the calc as `IncomingDamage`; the defender owns `Combat.State.Blocking`:

```
IncomingDamage  = 50 × (1 − 0.6 Block channel)        = 20.0
EffectiveDamage = max(0, 20 − 10 Defense)             = 10.0
Health          = 200 − 10 (EffectiveDamage)          = 190.0
GuardHealth     = 80  − 30 (heavy guard damage)       = 50.0
Poise           = 100 − 10 (heavy block-poise chip)   = 90.0
Super           = 0   + 8  (meter for taking the hit) = 8.0
MoveSpeed       = 500 × (1 − 0.5 Block channel)       = 250.0
```

These are exactly the `CurrentValue` entries recorded for the example fighter.

## Engine seam an adopter must implement

**`ExecCalc_MeleeResolution`** — the single custom `Execution` (core §9.5) the pack names. It couples the source's `AttackPower` (× the move multiplier), the target's flat `Defense`, the `Block` channel reduction, poise damage, guard damage, and the super gain for both fighters; honors `Team.Friendly` targets (skips friendly fire); and writes `EffectiveDamage` for telemetry/UI. Everything else in the pack is data.

## Validation

`python scripts/validate_schema_examples.py` **passes** — `Schema example validation passed. Validated 123 snippets.` (the whole `genres/` tree, including all 16 new combat entity files). Every entity carries the `%%UGAS_VERSION%%` `$schema` placeholder and uses only schema-defined fields.

Registered the pack with one row in `genres/README.md` and one entry in `genres/index.adoc`, and added `.changeset/genre-pack-combat.md`.

Closes #38. Part of #28.
