### PR TITLE
docs: correct case-study section references in genre packs (§15→§16)

### DIFF
--- a/.changeset/fix-genre-pack-section-refs.md
+++ b/.changeset/fix-genre-pack-section-refs.md
@@ -1,0 +1,5 @@
+---
+'ugas': patch
+---
+
+[Fixed] Corrected stale core-spec section cross-references in the Action, Racing, and RPG genre packs. The Case Studies moved from §15 to §16 when the State Persistence section (§14) was inserted (#63), so `genres/{action,racing,rpg}/spec.adoc` now cite §16.x, and the `genres/_template` authoring note points to §16. Documentation only — no entity or behavior changes.

--- a/genres/_template/spec.adoc
+++ b/genres/_template/spec.adoc
@@ -23,7 +23,7 @@ Mickael Bonfill <jbltx>
 // TODO: One paragraph describing the genre, the kind of games it targets, and
 // which UGAS pillars it leans on most. Link the matching core case study, e.g.
 // the Platformer / Racing / ARPG / Puzzle studies in
-// link:../../SPEC.adoc[the core specification] (Section 15, Case Studies).
+// link:../../SPEC.adoc[the core specification] (Section 16, Case Studies).
 
 [[relationship-to-core-spec]]
 == Relationship to the core specification

--- a/genres/action/spec.adoc
+++ b/genres/action/spec.adoc
@@ -22,7 +22,7 @@ form and grant abilities, and a movement *state machine* — grounded, airborne,
 that has to stay consistent while abilities, physics, and power-ups all read and write it.
 
 It is the practical, copy-and-extend companion to the *Platformer (Mario-style)* case study in
-link:../../SPEC.adoc[the core specification] (Section 15.1). Where the case study sketches the
+link:../../SPEC.adoc[the core specification] (Section 16.1). Where the case study sketches the
 movement attribute set, the variable-height `GA_Jump`, and power-up effects, this pack ships the
 matching schema-conformant Attributes, Tags, Abilities, and Effects in `entities/`, plus a worked
 hero in `entities/gameplay_controller.yaml`.
@@ -41,7 +41,7 @@ Effects on top of the core Universal Gameplay Ability System specification.
 * All entities in `entities/` validate against the same `schemas/*.json` as the core.
 * It *reuses* the core lifecycle tags (`State.Alive`, `State.Combat`, `State.Dead`) by reference,
   and adds the platformer movement states (`State.Grounded`, `State.InAir`, …) introduced by the
-  §15.1 case study.
+  §16.1 case study.
 * Movement state is mutated *only through Effects* (core spec §3.1) — abilities never write tags
   directly — and the size/speed power-up stacking is the core modifier `Channel` mechanism
   (link:../../SPEC.adoc[core spec] §5.3), not a new construct.
@@ -132,7 +132,7 @@ Defined in `entities/tag_registry.yaml` (additive only):
   applies the jump impulse, applies `GE_JumpCut` on early release, and cleans up both on landing.
 * `entities/ability_ground_pound.yaml` — `GA_GroundPound`: an airborne slam. Requires `State.InAir`,
   blocked while `State.Grounded`, and on `Event.Landed` applies `GE_ContactDamage` to every enemy in
-  radius — skipping `Immunity.Contact` targets. Models the §15.3 radius/tag-query pattern for action.
+  radius — skipping `Immunity.Contact` targets. Models the §16.3 radius/tag-query pattern for action.
 
 [[genre-effects]]
 == Genre Effects

--- a/genres/racing/spec.adoc
+++ b/genres/racing/spec.adoc
@@ -23,7 +23,7 @@ that modify performance, signature driver abilities (nitro, drift), and — at i
 at once.
 
 It is the practical, copy-and-extend companion to the *Racing (Forza-style)* case study in
-link:../../SPEC.adoc[the core specification] (Section 15.2). Where the case study sketches the
+link:../../SPEC.adoc[the core specification] (Section 16.2). Where the case study sketches the
 vehicle attribute set, biome surface effects, and the traction `ExecutionCalculation`, this pack
 ships the matching schema-conformant Attributes, Tags, Abilities, and Effects in `entities/`, plus
 a worked vehicle in `entities/gameplay_controller.yaml`.
@@ -39,7 +39,7 @@ Effects on top of the core Universal Gameplay Ability System specification.
 * It *reuses* core state tags (`State.Alive`, `State.Combat`, …) by reference where relevant —
   it never re-declares them.
 * The grip stacking it relies on is the core modifier `Channel` mechanism
-  (link:../../SPEC.adoc[core spec] §5.3 and §15.2), and the non-linear physics coupling is a core
+  (link:../../SPEC.adoc[core spec] §5.3 and §16.2), and the non-linear physics coupling is a core
   `ExecutionCalculation` — neither is a new construct.
 
 [[genre-attributes]]
@@ -70,7 +70,7 @@ this in two complementary layers, both landing on `TireGripMultiplier` / `Availa
 === Declarative grip channels
 
 Surface and upgrade modifiers stack through *named channels*: additive *within* a channel,
-multiplicative *across* channels — exactly the damage-bucket mechanism from §15.3, reused for grip.
+multiplicative *across* channels — exactly the damage-bucket mechanism from §16.3, reused for grip.
 
 [cols="1,3,2",options="header"]
 |===
@@ -100,7 +100,7 @@ Downforce scaling (latexmath:[\propto \text{speed}^2]) and the tire-temperature 
 *non-linear*, so they live in an `ExecutionCalculation` rather than a channel. `GE_Traction_Update`
 (`entities/effect_traction_update.yaml`) invokes `ExecCalc_VehicleTraction`, which reads the
 aggregated `TireGripMultiplier`, `AeroDownforce`, `TireTemperature`, and `CurrentSpeed` and writes
-`AvailableTraction`. The simulation re-applies this instant effect each physics step. See §15.2 for
+`AvailableTraction`. The simulation re-applies this instant effect each physics step. See §16.2 for
 the reference calculation body.
 
 [[genre-tags]]

--- a/genres/rpg/spec.adoc
+++ b/genres/rpg/spec.adoc
@@ -22,7 +22,7 @@ signature abilities, and — above all — a *multiplicative damage pipeline* th
 sane as item counts grow.
 
 It is the practical, copy-and-extend companion to the *ARPG (Diablo-style)* case study in
-link:../../SPEC.adoc[the core specification] (Section 15.3). Where the case study explains the
+link:../../SPEC.adoc[the core specification] (Section 16.3). Where the case study explains the
 _Damage Bucket_ architecture, this pack ships the matching schema-conformant Attributes, Tags,
 Abilities, and Effects in `entities/`, plus a worked hero in `entities/gameplay_controller.yaml`.
 
@@ -37,7 +37,7 @@ Effects on top of the core Universal Gameplay Ability System specification.
 * It *reuses* core state tags (`State.Alive`, `State.Combat`, `State.Dead`,
   `State.Debuff.Stunned`, `State.Buff.Regenerating`) by reference — it never re-declares them.
 * The damage-bucket stacking it relies on is the core modifier `Channel` mechanism
-  (link:../../SPEC.adoc[core spec] §5.3 and §15.3), not a new construct.
+  (link:../../SPEC.adoc[core spec] §5.3 and §16.3), not a new construct.
 
 [[genre-attributes]]
 == Genre Attributes
@@ -103,7 +103,7 @@ Defined in `entities/tag_registry.yaml` (additive only):
 * `entities/ability_whirlwind.yaml` — `GA_Whirlwind`: signature melee AoE. Tagged
   `Ability.Type.Melee` + `DamageType.Physical`, blocked while `State.Dead` /
   `State.Debuff.Stunned`, applies the damage effect to every target in radius while skipping
-  `Immunity.Physical` targets. Models the `GA_Whirlwind` tag-query example from §15.3.
+  `Immunity.Physical` targets. Models the `GA_Whirlwind` tag-query example from §16.3.
 
 [[genre-effects]]
 == Genre Effects


### PR DESCRIPTION
## What

The Case Studies section of the core spec moved from **§15 to §16** when the *State Persistence* section was inserted as §14 in Part 4 ([#63](https://github.com/jbltx/ugas/pull/63)). This also shifted Implementation Examples to §15. Three already-merged genre packs still cited the old §15.x case-study numbers and were stale on `develop`. This corrects them.

## Changes (11 references, documentation only)

- `genres/action/spec.adoc` — §15.1 → §16.1 (Platformer); §15.3 → §16.3 (ARPG tag-query pattern)
- `genres/racing/spec.adoc` — §15.2 → §16.2 (Racing); §15.3 → §16.3 (damage-bucket mechanism)
- `genres/rpg/spec.adoc` — §15.3 → §16.3 (ARPG)
- `genres/_template/spec.adoc` — authoring note 'Section 15, Case Studies' → §16

Verified against the authoritative heading text in `spec/part-5-reference-implementation/16-case-studies.adoc` (16.1 Platformer, 16.2 Racing, 16.3 ARPG, 16.4 Puzzle) and the schema's own `§16.3` reference. No §14 (Implementation-Examples) references existed in the packs. References to §3–§9 (e.g. §5.3 Channel Aggregation) were untouched — those sit before the inserted §14 and did not shift.

The six newer genre packs (Combat, Strategy, Sports, Puzzle, Casual, Survival/Crafting) already cite the correct numbers. No entity or behavior changes; includes a `'ugas': patch` changeset.