### PR TITLE
fix(spec): define deterministic RNG for predicted ExecutionCalculations (#5)

### DIFF
--- a/.changeset/spec-deterministic-predicted-rng.md
+++ b/.changeset/spec-deterministic-predicted-rng.md
@@ -1,0 +1,9 @@
+---
+'ugas': minor
+---
+
+[Added] Normative rule for randomness in Execution Calculations (§9.5) that resolves the predicted-RNG desync: any randomness consumed during a *predicted* Execution Calculation MUST be drawn from a deterministic, seeded stream exposed as `context.RNG`, seeded from `PredictionKey.Seed` (§13.8.1) and positioned per the `(Sub, draw index)` scheme so a predicting client and the authoritative server roll identically and no rollback is caused by RNG drift. Defines the small `DeterministicRNG` interface (`NextFloat()` / `NextInt(min, max)`) that conforming implementations MUST provide on the calculation `context`, and adds the matching `RNG: DeterministicRNG` field to the `EffectContext` struct (§9.9). Forbids ambient `RandomFloat()`-style globals for gameplay-affecting rolls, including in single-player / non-networked play (where the same `context.RNG` path is seeded from a local source).
+
+[Added] Non-predictable escape hatch: a calculation that genuinely needs non-reproducible or server-only randomness MUST declare `Predictable = false` (a `RequiresServerAuthority` marker) on `ExecutionCalculation`, in which case the activation aborts prediction and falls back to server authority for the random outcome, tied to the §13.8.2 fallback.
+
+[Fixed] §15.4 `ExecCalc_ArmorPenetration` replaced the bare `if (RandomFloat() < critChance)` critical-hit roll with `if (context.RNG.NextFloat() < critChance)` and a comment pointing to the §9.5 rule and the §13.8.1 seed. Documentation only — no schema or entity changes; references the §13.8.1 `PredictionKey.Seed` hook without modifying §13. Closes #5.

--- a/spec/part-2-core-components/09-gameplay-effects.adoc
+++ b/spec/part-2-core-components/09-gameplay-effects.adoc
@@ -264,6 +264,18 @@ abstract class ExecutionCalculation {
   /** Attributes to capture from target */
   TargetCaptureDefinitions: AttributeCapture[];
 
+  /**
+   * Whether this calculation may run inside a client-side prediction
+   * (§13.4). Defaults to `true`. A calculation that consumes randomness
+   * MUST either draw it from `context.RNG` (the deterministic, seeded
+   * stream — see "Randomness in Execution Calculations" below) so it
+   * stays predictable, or set this to `false` to declare that it
+   * requires server authority and cannot be predicted. When `false`,
+   * the activation that triggers this calculation MUST abort prediction
+   * and fall back to server authority (§13.8.2) for the random outcome.
+   */
+  Predictable: boolean;  // default: true
+
   /** Perform the calculation */
   abstract Execute(
     source: CapturedAttributes,
@@ -314,6 +326,38 @@ class ExecCalc_PhysicalDamage extends ExecutionCalculation {
   }
 }
 ----
+
+_Randomness in Execution Calculations (Normative)_
+
+Execution Calculations frequently make randomized decisions — a critical-hit roll, a random damage spread, a proc chance. Because the same calculation runs on a predicting client (§13.4) and on the authoritative server, naive randomness drawn from an ambient global (e.g. a bare `RandomFloat()`) will diverge: at `CriticalChance = 0.5` the client mispredicts the crit roughly half the time, forcing a visible rollback (§13.5) on every disagreement. The following rules make randomness in Execution Calculations deterministic and reproducible across client and server.
+
+. *Seeded, deterministic stream.* Any randomness consumed during a *predicted* Execution Calculation MUST be drawn from the deterministic RNG stream exposed as `context.RNG`. That stream MUST be seeded from the activation's `PredictionKey.Seed` (§13.8.1) and advanced deterministically, so that the predicting client and the authoritative server, starting from the same server-coordinated seed, produce identical results and no rollback is caused by RNG drift alone.
+. *No ambient randomness.* Implementations MUST NOT consume gameplay-affecting randomness during prediction from any source other than `context.RNG` (this mirrors the prohibition in §13.8.1). A bare `RandomFloat()`-style global, a thread-local PRNG, wall-clock time, or any other non-seeded source MUST NOT be used for a roll that influences gameplay state.
+. *Stream positioning (reproducibility).* `context.RNG` MUST be positioned per the `(Sub, draw index)` scheme of §13.8.1: each activation under a prediction `Base` consumes a disjoint sub-stream selected by its `PredictionKey.Sub`, and successive draws within one `Execute()` advance a monotonic draw index. Consequently, the _n_-th draw of a given calculation under a given `(Base, Sub)` is reproducible — re-running `Execute()` during reconciliation replay (§13.5) yields the same sequence. Implementations MUST NOT make the result depend on draw _ordering across_ calculations that is not itself deterministic.
+. *Non-predictable opt-out (escape hatch).* An Execution Calculation that genuinely requires non-reproducible or server-only randomness — for example, a roll that MUST NOT be inferable client-side, or one seeded from a source the client cannot reproduce — MUST declare itself non-predictable by setting `Predictable = false` (equivalently, carrying a `RequiresServerAuthority` marker). When such a calculation participates in an activation, that activation MUST abort prediction and fall back to awaiting server authority for the random outcome, exactly as in the prediction-window fallback of §13.8.2; the authoritative result then replicates normally. This is the second option called out by issue #5: random Execution Calculations that cannot be predicted abort to server authority rather than mispredict.
+. *Single-player / non-networked.* The same `context.RNG` path is used when there is no server: the stream is seeded from a local source (e.g. a per-session or per-activation seed) instead of `PredictionKey.Seed`. No `RandomFloat()`-style ambient global is permitted for gameplay-affecting rolls even offline, so that calculation behavior is identical in shape across networked and standalone play and remains reproducible for replays and tests.
+
+`context.RNG` is a small `DeterministicRNG` interface that conforming implementations MUST provide on the Execution Calculation `context`:
+
+[source,typescript]
+----
+interface DeterministicRNG {
+  /** Next uniform float in [0, 1). Advances the stream by one draw. */
+  NextFloat(): float;
+
+  /**
+   * Next integer in [minInclusive, maxExclusive). Advances the stream by
+   * one draw. Derived deterministically from the same sequence as
+   * NextFloat(), so a given draw index yields a stable value.
+   */
+  NextInt(minInclusive: int, maxExclusive: int): int;
+}
+----
+
+[NOTE]
+====
+The seed itself is owned by the networking layer, not by the Execution Calculation: §13.8.1 defines `PredictionKey.Seed` as server-coordinated and forbids client-chosen seeds (so a client cannot bias a predicted crit). §9.5 only defines the _consumption_ contract — how a calculation draws from that seed via `context.RNG`. A calculation MUST NOT read `PredictionKey.Seed` directly or reconstruct its own RNG; it MUST go through `context.RNG` so stream positioning stays consistent with §13.8.1.
+====
 
 ==== 9.6 Execution Policies
 
@@ -479,6 +523,16 @@ struct EffectContext {
 
   /** World location for positional effects */
   WorldOrigin?: Vector3;
+
+  /**
+   * Deterministic, seeded RNG for any randomness consumed by an Execution
+   * Calculation (§9.5). During prediction this stream is seeded from
+   * `PredictionKey.Seed` (§13.8.1) and positioned per the (Sub, draw index)
+   * scheme so client and server agree; offline it is seeded from a local
+   * source. Gameplay-affecting rolls MUST use this rather than an ambient
+   * global. See "Randomness in Execution Calculations" in §9.5.
+   */
+  RNG: DeterministicRNG;
 }
 ----
 

--- a/spec/part-5-reference-implementation/15-implementation-examples.adoc
+++ b/spec/part-5-reference-implementation/15-implementation-examples.adoc
@@ -235,8 +235,15 @@ class ExecCalc_ArmorPenetration extends ExecutionCalculation {
     // Base damage
     let damage = attackPower * (1 - armorDR);
 
-    // Apply critical hit
-    if (RandomFloat() < critChance) {
+    // Apply critical hit.
+    // Draw from the deterministic, seeded stream (context.RNG) rather than a
+    // bare RandomFloat(), so a predicting client and the server roll the same
+    // crit and avoid a rollback. The stream is seeded from PredictionKey.Seed
+    // (§13.8.1) and positioned per the (Sub, draw index) scheme; see the
+    // "Randomness in Execution Calculations" rule in §9.5. (This calculation
+    // stays Predictable; a roll that must be server-only would instead set
+    // Predictable = false and abort prediction per §13.8.2.)
+    if (context.RNG.NextFloat() < critChance) {
       damage *= critDamage;
       context.SetTag("Hit.Critical");
     }


### PR DESCRIPTION
## Problem (issue #5)

§15.4 `ExecCalc_ArmorPenetration` rolled its critical hit with a bare `RandomFloat()`:

```typescript
if (RandomFloat() < critChance) { damage *= critDamage; ... }
```

In the server-authoritative + client-prediction model (§13.4), the same ExecutionCalculation runs on both the predicting client and the server. With an ambient, unseeded global RNG the two sides draw independent values, so at `CriticalChance = 0.5` the client mispredicts the crit ~50% of the time, forcing a visible rollback (§13.5) on every disagreement. The spec defined the seed hook (§13.8.1 `PredictionKey.Seed`) but never defined the ExecutionCalculation-side rule that consumes it. This PR adds that rule.

## Design

Additive, RFC-2119 clarification — no contradiction with §9.5, §13.8, or any other section; no renumbering.

**§9.5 — new normative subsection "Randomness in Execution Calculations":**
- Any randomness consumed during a **predicted** ExecutionCalculation MUST be drawn from a deterministic, seeded stream exposed as **`context.RNG`**, seeded from the activation's `PredictionKey.Seed` (§13.8.1) and advanced deterministically, so client and server produce identical results.
- **Stream positioning** follows the `(Sub, draw index)` scheme of §13.8.1: each activation under a prediction `Base` gets a disjoint sub-stream keyed by `PredictionKey.Sub`, and draws within one `Execute()` advance a monotonic index — so the _n_-th draw is reproducible across reconciliation replay (§13.5).
- No ambient `RandomFloat()`-style global / thread-local PRNG / wall-clock source is permitted for gameplay-affecting rolls.
- **Escape hatch:** a calculation that genuinely needs non-reproducible or server-only randomness MUST declare `Predictable = false` (a `RequiresServerAuthority` marker) on `ExecutionCalculation`; the activation then aborts prediction and falls back to server authority for the random outcome, tied to the §13.8.2 fallback.
- **Single-player / non-networked:** same `context.RNG` path, seeded from a local source; no ambient global even offline (keeps behavior identical in shape and reproducible for replays/tests).

**Interface introduced** (implementations MUST provide it on the calculation `context`):

```typescript
interface DeterministicRNG {
  NextFloat(): float;                                  // uniform [0, 1)
  NextInt(minInclusive: int, maxExclusive: int): int;  // same sequence
}
```

**Non-predictable marker:** `Predictable: boolean` (default `true`) added to the `ExecutionCalculation` abstract class; `Predictable = false` is the `RequiresServerAuthority` opt-out.

**§9.9** — `RNG: DeterministicRNG` added to the `EffectContext` struct so the documented `context` fields stay consistent.

**§15.4** — the crit roll now reads `if (context.RNG.NextFloat() < critChance)`, with a comment pointing to the §9.5 rule and the §13.8.1 seed. Rest of the example unchanged.

The seed remains owned by the networking layer (§13.8.1, server-coordinated, client-chosen seeds forbidden so a client cannot bias a predicted crit); §9.5 defines only the *consumption* contract and forbids reading `PredictionKey.Seed` directly.

## Alternatives considered

- **Per-calculation RNG seeded directly from `PredictionKey.Seed`, no shared interface** — every calc would re-derive its own stream and risk inconsistent positioning vs. the §13.8.1 `(Sub, draw index)` scheme. Rejected in favor of a single `context.RNG` the implementation positions centrally.
- **"Random calcs simply cannot be predicted" (always abort)** — issue #5 lists this as an option. Too blunt: it gives up responsiveness for the common predictable case (crit rolls). Kept as the explicit `Predictable = false` opt-out for the genuinely-unpredictable case instead of the default.
- **Client-chosen seed / client-local RNG** — rejected (and already forbidden by §13.8.1): a client-chosen seed lets a client bias predicted random outcomes.

Issue #5's three suggested options map to this design: seed from the prediction key (primary path), abort-to-authority for unpredictable calcs (the `Predictable = false` hatch), and a `PredictedRNG`-style interface implementations must provide (`DeterministicRNG`).

## Files

- `spec/part-2-core-components/09-gameplay-effects.adoc` (§9.5 rule + `DeterministicRNG` + `Predictable` marker; §9.9 `EffectContext.RNG`)
- `spec/part-5-reference-implementation/15-implementation-examples.adoc` (§15.4 seeded crit roll)
- `.changeset/spec-deterministic-predicted-rng.md` (`'ugas': minor`)

§13 (`13-network-replication.adoc`) and §08 (`08-gameplay-abilities.adoc`) intentionally untouched.

## Validation

`scripts/validate_schema_examples.py` passes — "Schema example validation passed. Validated 258 snippets." (deps installed in a local `.venv`, not committed; `.venv/` is gitignored). asciidoctor isn't available locally, so AsciiDoc rendering relies on the CI `preview-docs` job.

Closes #5