### PR TITLE
spec: World & Spatial Model pillar — §17 foundation (anchors + query model)

### DIFF
--- a/.changeset/spec-world-spatial-model.md
+++ b/.changeset/spec-world-spatial-model.md
@@ -1,0 +1,5 @@
+---
+'ugas': minor
+---
+
+[Added] World & Spatial Model pillar (§17), foundation. UGAS was position-agnostic; §17 makes the spatial model first-class and normative as an engine seam (the spec defines the model + query contract; the engine provides the spatial index). This first installment defines §17.1 **Spatial Anchors** (a GC's world position via its Avatar, or an explicit `WorldOrigin`; GCs without a position are non-spatial and invisible to queries) and §17.2 the **Spatial Query Model** — a normative `SpatialQuery` interface (`Distance`, `OverlapSphere`/`Box`/`Capsule`/`Cone`, `LineOfSight`, `Nearest`) with a `SpatialFilter` (tag/affiliation/max-results) and normative semantics (filter-then-test, self handling, determinism for §17.7 prediction, non-spatial exclusion, §10.6 tick budgets). Appended as §17 to avoid renumbering §4–§16 and their cross-references. First of a split series for the spatial pillar (range/multi-target, zones, perception, partitioning, prediction to follow); documentation only — no schema or entity changes yet.

--- a/SPEC.adoc
+++ b/SPEC.adoc
@@ -72,6 +72,8 @@ include::spec/part-4-feedback-and-networking.adoc[]
 
 include::spec/part-5-reference-implementation.adoc[]
 
+include::spec/part-6-world-and-space.adoc[]
+
 [appendix]
 === Mathematical Notation
 

--- a/spec/part-6-world-and-space.adoc
+++ b/spec/part-6-world-and-space.adoc
@@ -1,0 +1,3 @@
+== Part VI: World & Spatial Model
+
+include::part-6-world-and-space/17-world-spatial-model.adoc[]

--- a/spec/part-6-world-and-space/17-world-spatial-model.adoc
+++ b/spec/part-6-world-and-space/17-world-spatial-model.adoc
@@ -1,0 +1,129 @@
+=== 17. World & Spatial Model
+
+UGAS is otherwise position-agnostic: Attributes, Tags, Effects, and Abilities describe _what_ an
+entity is and _what happens to it_, not _where_ it is. Yet most genres need spatial reasoning — an
+area-of-effect blast, a weapon's range, a perception radius, a capture zone. Until now the
+specification only _gestured_ at space: `EffectContext.WorldOrigin` and `HitResult` (§9.9), the
+`WaitOverlap` / `WaitForTarget` tasks categorised "Spatial" with their tick budgets (§10.3, §10.6),
+the Avatar's "spatial position for targeting" (§4.2), and the "range, line-of-sight" reachability
+check delegated to the title (§13.7). This section makes the spatial model *first-class and
+normative*.
+
+Like Execution Calculations (§9.5), the spatial model is an *engine seam*: this specification defines
+the _data model_ and the _query contract_; the implementing engine provides the spatial index (uniform
+grid, BVH, physics scene, tilemap, …) that answers the queries. UGAS does not mandate a partitioning
+structure — that is the subject of §17.6 — only that the queries defined here are answerable and behave
+as specified.
+
+[NOTE]
+====
+This pillar is appended at §17 (rather than inserted among the Part II pillars) to avoid renumbering
+§4–§16 and the many cross-references to them, including those in the genre packs. It is nonetheless a
+core gameplay concept and is intended to be read alongside the Part II pillars.
+====
+
+==== 17.1 Spatial Anchors
+
+A *spatial anchor* is the position — and optional orientation — at which a Gameplay Controller exists
+in the world. Spatial queries operate over anchors, not over GCs directly, so a purely non-spatial GC
+(an inventory, a party roster, a global rules controller) simply has no anchor and is invisible to
+spatial queries.
+
+[source,typescript]
+----
+struct SpatialAnchor {
+  /**
+   * The world position. The coordinate frame, units, and handedness are engine-defined; this
+   * specification treats positions as opaque points and requires only that the §17.2 queries behave
+   * as specified over them.
+   */
+  Position: Vector3;
+
+  /** Optional facing, used by directional queries (cones, forward line-of-sight). Identity if absent. */
+  Orientation?: Quaternion;
+
+  /** The GC this anchor represents. */
+  Owner: GameplayController;
+}
+----
+
+The Avatar (§4.2) is the canonical source of a GC's anchor: a spatially-present GC's anchor position
+is its Avatar's world position. A GC MAY also expose an anchor without an Avatar — for example a
+ground-targeted area effect anchored at a `WorldOrigin`; `EffectContext.WorldOrigin` (§9.9) is exactly
+the anchor of a positional effect application.
+
+* A GC's anchor, when it has one, MUST reflect its Avatar's current world position at the time a query
+  is evaluated.
+* An implementation MUST treat a GC with neither an Avatar nor an explicit position as *non-spatial*:
+  it is never returned by a spatial query and never participates in range, zone, or perception checks.
+
+==== 17.2 Spatial Query Model
+
+All spatial gameplay reduces to a small set of *queries* over anchors. An implementation MUST provide a
+query provider satisfying the contract below; how it indexes anchors to answer them efficiently is its
+own concern (§17.6).
+
+[source,typescript]
+----
+/** Restricts a query's candidate set before distance/shape tests are applied. */
+struct SpatialFilter {
+  /** Candidate must own ALL of these tags (§7, hierarchical). Empty = no tag requirement. */
+  RequireTags?: GameplayTag[];
+
+  /** Candidate must own NONE of these tags. */
+  ExcludeTags?: GameplayTag[];
+
+  /**
+   * Affiliation of the candidate relative to the querying GC, resolved by the implementation's team
+   * model: Any | Allied | Hostile | Neutral | SelfOnly | ExcludeSelf.
+   */
+  Affiliation?: Affiliation;
+
+  /** Hard cap on the number of results (0 = unbounded), combined with a query's own ordering. */
+  MaxResults?: int;
+}
+
+interface SpatialQuery {
+  /** Distance between two anchors (or anchor and point), in engine units. */
+  Distance(a: SpatialAnchor | Vector3, b: SpatialAnchor | Vector3): float;
+
+  /** Anchors whose position lies within `radius` of `center`, matching `filter`. */
+  OverlapSphere(center: Vector3, radius: float, filter: SpatialFilter): SpatialAnchor[];
+
+  /** Anchors within an oriented box, a capsule, or a forward cone (directional shapes use Orientation). */
+  OverlapBox(center: Vector3, halfExtents: Vector3, orientation: Quaternion, filter: SpatialFilter): SpatialAnchor[];
+  OverlapCapsule(p0: Vector3, p1: Vector3, radius: float, filter: SpatialFilter): SpatialAnchor[];
+  OverlapCone(apex: Vector3, direction: Vector3, range: float, halfAngleDeg: float, filter: SpatialFilter): SpatialAnchor[];
+
+  /** Whether `b` is visible from `a` with no occluder between them. Occlusion is engine-defined. */
+  LineOfSight(a: Vector3, b: Vector3): boolean;
+
+  /** The `count` nearest anchors to `center` matching `filter`, ordered nearest-first. */
+  Nearest(center: Vector3, count: int, filter: SpatialFilter): SpatialAnchor[];
+}
+----
+
+===== Query semantics (normative)
+
+. *Filter, then test.* `SpatialFilter` MUST be applied so only matching anchors are considered. Tag
+  tests use the hierarchical semantics of §7 (a `RequireTags` of `Faction.Enemy` matches
+  `Faction.Enemy.Elite`). `Affiliation` is resolved relative to the querying GC by the implementation's
+  team model.
+. *Self handling.* A query MUST exclude the querying GC's own anchor unless `Affiliation` is `SelfOnly`
+  or otherwise includes self. `ExcludeSelf` is the appropriate default for area effects.
+. *Determinism.* For a fixed world state and identical inputs, a query MUST return the same set, and
+  ordered queries (`Nearest`) MUST return a stable order, with ties broken deterministically (e.g. by
+  GC id). This is required for the predicted spatial queries of §17.7.
+. *Non-spatial GCs* (§17.1) are never returned.
+. *Cost.* Queries are not free. Their tick cadence is governed by the §10.6 spatial task budgets
+  (gameplay-critical hit/target detection every frame; ambient/aura acquisition every 50–100 ms).
+  Implementations SHOULD answer queries from a spatial partition (§17.6) rather than scanning all GCs.
+
+[NOTE]
+====
+The remaining subsections build directly on this contract: range and area effects (§17.3) combine
+`OverlapSphere`/`OverlapCone` with a `MaxRange`; zones (§17.4) are standing region queries that grant
+tags on entry/exit; perception (§17.5) composes `OverlapSphere` with `LineOfSight`; partitioning
+(§17.6) is how an engine answers all of the above efficiently; and predicted spatial queries (§17.7)
+rely on the determinism of semantic rule 3.
+====


### PR DESCRIPTION
**Phase 1 (Workstream A), PR 1 of the spatial-pillar series.** Adds the World & Spatial Model pillar foundation to the UGAS spec.

## What & why
UGAS was position-agnostic, yet most genres need spatial reasoning (AoE, range, perception, zones) — today only *gestured* at via `EffectContext.WorldOrigin` (§9.9), the "Spatial" tasks (§10.3/§10.6), Avatar position (§4.2), and the delegated §13.7 reachability check. §17 makes it **first-class and normative**, as an **engine seam** (like ExecutionCalculations §9.5): the spec defines the model + query contract; the engine provides the spatial index.

- **§17.1 Spatial Anchors** — a GC's world position (via its Avatar, or an explicit `WorldOrigin`); GCs with no position are *non-spatial* and never returned by queries.
- **§17.2 Spatial Query Model** — a normative `SpatialQuery` interface (`Distance`, `OverlapSphere`/`Box`/`Capsule`/`Cone`, `LineOfSight`, `Nearest`) + a `SpatialFilter` (tag / affiliation / max-results), with normative semantics: filter-then-test, self handling, **determinism** (required by §17.7 prediction), non-spatial exclusion, and §10.6 tick budgets.

## Placement
Appended as **§17 (new Part VI)** rather than inserted among the Part II pillars — to avoid renumbering §4–§16 and the many cross-references to them (incl. the genre packs), the same churn the §14 insertion caused.

## Series
Split, reviewable PRs to follow: range/multi-target → zones → perception → partitioning → prediction. (`'ugas': minor`.)

Documentation only — no schema/entity changes yet. `validate_schema_examples.py`: **258 snippets pass**. asciidoctor isn't available locally; rendered build relies on CI `preview-docs`.