### PR TITLE
spec: World & Spatial §17.3 — range + area application (schema: MaxRange, Area)

### DIFF
--- a/.changeset/spec-world-spatial-range-area.md
+++ b/.changeset/spec-world-spatial-range-area.md
@@ -1,0 +1,5 @@
+---
+'ugas': minor
+---
+
+[Added] World & Spatial Model §17.3 (Range and Area Application) plus the schema fields that back it. `MaxRange` is added to the ability schema — a target-requiring activation must be within range (§17.2 `Distance`), validated server-side per §13.7. An optional `Area` block is added to the effect schema (Shape `Sphere`/`Cone`, an `AttributeBased`-capable `Radius`, a tag/affiliation filter, and `MaxTargets`) so an effect can apply to every matching anchor within an area via a single §17.2 query — the multi-target/AoE capability the genre packs previously faked with a hard-coded task-parameter radius. Both `.json`/`.yaml` schema twins updated; additive and backward-compatible (no new `required` fields, no `additionalProperties: false`). Second installment of the spatial-pillar series.

--- a/schemas/gameplay_ability.json
+++ b/schemas/gameplay_ability.json
@@ -72,6 +72,11 @@
       "type": "string",
       "description": "Reference to cooldown GameplayEffect"
     },
+    "MaxRange": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Maximum targeting range in engine units (§17.3). Absent or 0 means self-targeted / no range gate; a target-requiring activation MUST be within range (§17.2 Distance), validated server-side per §13.7."
+    },
     "AsyncValidation": {
       "type": "object",
       "description": "Optional asynchronous server-side validation for activation (§8.8). When present and Required is true, an activation that passes the synchronous checks enters PendingConfirmation before Commit instead of committing synchronously.",

--- a/schemas/gameplay_ability.yaml
+++ b/schemas/gameplay_ability.yaml
@@ -52,6 +52,10 @@ properties:
   Cooldown:
     type: string
     description: Reference to cooldown GameplayEffect
+  MaxRange:
+    type: number
+    minimum: 0
+    description: "Maximum targeting range in engine units (§17.3). Absent or 0 means self-targeted / no range gate; a target-requiring activation MUST be within range (§17.2 Distance), validated server-side per §13.7."
   AsyncValidation:
     type: object
     description: Optional asynchronous server-side validation for activation (§8.8). When present and Required is true, an activation that passes the synchronous checks enters PendingConfirmation before Commit instead of committing synchronously.

--- a/schemas/gameplay_effect.json
+++ b/schemas/gameplay_effect.json
@@ -106,6 +106,49 @@
         "type": "string"
       },
       "description": "Visual/audio cues to trigger"
+    },
+    "Area": {
+      "type": "object",
+      "description": "Optional area application (§17.3). When present, the effect applies to every anchor matching the filter within the shape (via the §17.2 spatial queries) instead of a single target; the execution policy (§9.6) governs per-target combination.",
+      "required": ["Shape"],
+      "properties": {
+        "Shape": {
+          "type": "string",
+          "enum": ["Sphere", "Cone"],
+          "description": "Query shape centered at the application origin (EffectContext.WorldOrigin, §9.9)."
+        },
+        "Radius": {
+          "$ref": "#/$defs/MagnitudeDefinition",
+          "description": "Sphere radius / cone range. May be AttributeBased to scale with an attribute (§9.4.2)."
+        },
+        "HalfAngleDeg": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 180,
+          "description": "Cone half-angle in degrees (Cone shape only)."
+        },
+        "RequireTags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Candidate must own all these tags (§7, hierarchical). Empty = no requirement."
+        },
+        "ExcludeTags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Candidate must own none of these tags."
+        },
+        "Affiliation": {
+          "type": "string",
+          "enum": ["Any", "Allied", "Hostile", "Neutral", "SelfOnly", "ExcludeSelf"],
+          "default": "ExcludeSelf",
+          "description": "Affiliation of candidates relative to the applying GC (§17.2)."
+        },
+        "MaxTargets": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Cap on affected targets (0 = unbounded), applied after ordering."
+        }
+      }
     }
   },
   "$defs": {

--- a/schemas/gameplay_effect.yaml
+++ b/schemas/gameplay_effect.yaml
@@ -88,6 +88,51 @@ properties:
     items:
       type: string
     description: Visual/audio cues to trigger
+  Area:
+    type: object
+    description: "Optional area application (§17.3). When present, the effect applies to every anchor matching the filter within the shape (via the §17.2 spatial queries) instead of a single target; the execution policy (§9.6) governs per-target combination."
+    required:
+      - Shape
+    properties:
+      Shape:
+        type: string
+        enum:
+          - Sphere
+          - Cone
+        description: "Query shape centered at the application origin (EffectContext.WorldOrigin, §9.9)."
+      Radius:
+        $ref: "#/$defs/MagnitudeDefinition"
+        description: "Sphere radius / cone range. May be AttributeBased to scale with an attribute (§9.4.2)."
+      HalfAngleDeg:
+        type: number
+        minimum: 0
+        maximum: 180
+        description: "Cone half-angle in degrees (Cone shape only)."
+      RequireTags:
+        type: array
+        items:
+          type: string
+        description: "Candidate must own all these tags (§7, hierarchical). Empty = no requirement."
+      ExcludeTags:
+        type: array
+        items:
+          type: string
+        description: "Candidate must own none of these tags."
+      Affiliation:
+        type: string
+        enum:
+          - Any
+          - Allied
+          - Hostile
+          - Neutral
+          - SelfOnly
+          - ExcludeSelf
+        default: ExcludeSelf
+        description: "Affiliation of candidates relative to the applying GC (§17.2)."
+      MaxTargets:
+        type: integer
+        minimum: 0
+        description: "Cap on affected targets (0 = unbounded), applied after ordering."
 
 $defs:
   MagnitudeDefinition:

--- a/spec/part-6-world-and-space/17-world-spatial-model.adoc
+++ b/spec/part-6-world-and-space/17-world-spatial-model.adoc
@@ -127,3 +127,52 @@ tags on entry/exit; perception (§17.5) composes `OverlapSphere` with `LineOfSig
 (§17.6) is how an engine answers all of the above efficiently; and predicted spatial queries (§17.7)
 rely on the determinism of semantic rule 3.
 ====
+
+==== 17.3 Range and Area Application
+
+The two most common spatial needs are expressed directly on the existing pillars via the §17.2 query
+model: an ability's *range* and an effect's *area* application.
+
+===== Targeting range
+
+An ability MAY declare a `MaxRange` (schema §8.7). When it targets another GC, the activation is valid
+only while the target's anchor is within `MaxRange` of the instigator's anchor
+(`SpatialQuery.Distance`, §17.2):
+
+* A range-gated activation whose target is out of range MUST fail activation — it does not commit
+  (§8.3). Under prediction the client MAY predict the range check, but the server's reachability
+  validation (§13.7) is authoritative.
+* `MaxRange` absent or `0` means the ability is self-targeted or imposes no range gate.
+* Range is measured between anchors (§17.1); an instigator or target without an anchor is, by
+  definition, out of range for a range-gated ability.
+
+===== Area application
+
+By default an effect applies to a single target (`ApplyGameplayEffectToTarget`, §13.7). An effect MAY
+instead declare an `Area` (schema §9): it is applied to _every_ anchor matching a filter within a
+shape, resolved by a single §17.2 query at the moment of application.
+
+[source,typescript]
+----
+// Resolve the target set once, then apply to each, honoring the §9.6 execution policy.
+function ApplyAreaEffect(instigator: GC, origin: Vector3, spec: EffectSpec, area: Area): void {
+  const hits = area.Shape === "Cone"
+    ? query.OverlapCone(origin, instigator.Facing, resolve(area.Radius), area.HalfAngleDeg, area.Filter)
+    : query.OverlapSphere(origin, resolve(area.Radius), area.Filter); // Sphere
+  for (const anchor of hits) // set already ordered + capped by MaxTargets
+    ApplyGameplayEffectToTarget(anchor.Owner, spec);
+}
+----
+
+Normative:
+
+. The target set MUST be resolved by a single query at application time — an area effect _snapshots_
+  who is in the area then; anchors entering the shape afterwards are not retroactively affected.
+. `Area.Radius` MAY be `AttributeBased` (§9.4.2), so an upgrade or stat can scale the radius — the
+  capability genre packs previously lacked (they hard-coded a constant radius in a task parameter).
+. The origin is the application anchor: `EffectContext.WorldOrigin` (§9.9) for a ground-targeted cast,
+  otherwise the instigator's or target's anchor.
+. Each per-target application obeys the effect's execution policy (§9.6) and the §13.7 authorization
+  checks exactly as a single-target application would; `MaxTargets` caps the set after ordering.
+. Under client-side prediction an area application is predicted only if its query is deterministic
+  (§17.2 rule 3, §17.7); otherwise it defers to server authority.


### PR DESCRIPTION
**Phase 1 spatial series, PR 2** (follows #79 foundation).

## Adds
- **§17.3 Range** — an ability's `MaxRange`: a target-requiring activation is valid only while the target's anchor is within range (`SpatialQuery.Distance`, §17.2); out-of-range fails activation; server reachability (§13.7) is authoritative.
- **§17.3 Area application** — an effect's `Area` block applies it to *every* anchor matching a filter within a shape, resolved by a single §17.2 query (snapshot at application time). `Radius` may be `AttributeBased` (§9.4.2) so upgrades/stats scale it — the AoE capability packs previously hard-coded in a task param. Per-target application honors the §9.6 execution policy + §13.7 auth; `MaxTargets` caps the set.

## Schema
- Ability: `MaxRange` (number). Effect: `Area` (Shape/Radius/HalfAngleDeg/RequireTags/ExcludeTags/Affiliation/MaxTargets). Both `.json`/`.yaml` twins; additive + backward-compatible (no new `required`, no `additionalProperties: false`).

Validators: **258 snippets pass**, **twin-equivalence passes**. asciidoctor relies on CI `preview-docs`.