### PR TITLE
feat(skills): confirm-before-write + pack-departure gates in authoring skills

### DIFF
--- a/.claude/skills/gameplay-creator-assistant/SKILL.md
+++ b/.claude/skills/gameplay-creator-assistant/SKILL.md
@@ -85,6 +85,22 @@ never pass through that pipeline, so a literal `%%UGAS_VERSION%%` would be an in
 5. **Validate** — Check every file against the fetched JSON schemas (or via
    `ugas-schema-author`) and fix every error before presenting the game.
 
+## Working autonomously (and as a harness building block)
+
+Prefer acting on sensible, pack-derived defaults over interrogating the user; in one-shot mode
+record them in the assumptions note you return. Two confirmations are worth a pause, because
+guessing wrong is expensive to undo:
+
+- **Before the first outward write.** Creating files or directories in the user's project (or a
+  new repo) is a real side effect — confirm the target location once before you start writing,
+  not once per file.
+- **Before a meaningful departure from the pack.** Dropping or replacing a genre's *signature*
+  mechanic reshapes the game — surface it and confirm rather than silently diverging. Cosmetic
+  changes (numbers, names, additive extensions) need no confirmation.
+
+When the `ugas-harness` skill is driving you, it owns these gates and its assumptions log — just
+surface departures and proceed; don't double-prompt.
+
 ## Relationship to `ugas-schema-author`
 
 These two skills are complementary. Route by scope:

--- a/.claude/skills/ugas-schema-author/SKILL.md
+++ b/.claude/skills/ugas-schema-author/SKILL.md
@@ -36,6 +36,16 @@ simulate, and balance gameplay entities conforming to the UGAS specification.
    (pair with the `xlsx` skill when available) or export projection results to
    spreadsheets for balancing workflows.
 
+## Working autonomously (and as a building block)
+
+Infer reasonable defaults from the request and the schemas and proceed — don't stall on details
+you can reasonably choose (note what you assumed). Pause for one thing: **confirm before the
+first outward write** — creating or overwriting files in the user's project is a real side
+effect, so confirm the target once before writing. When a higher-level skill (e.g.
+`gameplay-creator-assistant` or `ugas-harness`) is composing you, it owns confirmation and the
+assumptions log — surface your assumptions to it and proceed, rather than prompting the user
+yourself.
+
 ## Core concepts to remember
 
 The UGAS modifier pipeline computes CurrentValue as:


### PR DESCRIPTION
## What
The Ask-tool-gates half of #16 (roadmap Workstream C2). Adds a short **"Working autonomously"** note to each authoring skill so they behave well standalone *and* as `ugas-harness` building blocks:

- **`gameplay-creator-assistant`** — infer pack-derived defaults and proceed, but confirm (1) before the first **outward write** into the user's project, and (2) before a **meaningful departure** from a genre's signature mechanic; cosmetic changes need no confirmation.
- **`ugas-schema-author`** — infer and proceed, but confirm before the first outward write.

Both note that when a higher-level skill (the harness) is composing them, **it** owns the gates + assumptions log — they surface and proceed without double-prompting.

Additive prose only; no change to either skill's core flow or evals. No spec/schema changes → no Changeset.

## Closes
Completes **#16** (orchestrator skill landed in #83; these are the building-block gates it relies on).