### PR TITLE
spec(schema): scene schema (json + yaml) for §18 + arena example

### DIFF
--- a/.changeset/spec-scene-schema.md
+++ b/.changeset/spec-scene-schema.md
@@ -1,0 +1,5 @@
+---
+'ugas': minor
+---
+
+[Added] `scene` schema (JSON + YAML twins) for §18 Scene Composition. Validates a Scene's `Name` + `Placements` (`Controller`, `InstanceId`, `Position`/`Rotation`, `StartupTags`/`StartupEffects`, `AttributeOverrides`, `Enabled`), its `Regions` (§17.4), and its `SpawnPoints`. Registered with the schema-equivalence and example validators, with an `arena_scene.yaml` worked example. Completes the §18 authoring surface so scenes can be authored and machine-validated.

--- a/schemas/examples/arena_scene.yaml
+++ b/schemas/examples/arena_scene.yaml
@@ -1,0 +1,35 @@
+# Example: Arena Scene
+# A small combat arena — a player, two enemies, a hazard zone, and a respawn point.
+
+$schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/scene.json
+Name: Arena
+Placements:
+  - Controller: PlayerCharacter
+    InstanceId: player-1
+    Position: [0, 0, 0]
+    StartupTags:
+      - Faction.Player
+  - Controller: Goblin
+    InstanceId: goblin-1
+    Position: [5, 0, 3]
+    StartupTags:
+      - Faction.Enemy
+    AttributeOverrides:
+      Health: 60
+  - Controller: Goblin
+    InstanceId: goblin-2
+    Position: [-4, 0, 6]
+    StartupTags:
+      - Faction.Enemy
+Regions:
+  - Name: LavaPit
+    Shape: Sphere
+    Position: [0, 0, 10]
+    Radius: 4
+    GrantedTags:
+      - Zone.Hazard.Fire
+SpawnPoints:
+  - Name: PlayerRespawn
+    Position: [0, 0, -8]
+    Tags:
+      - Spawn.Player

--- a/schemas/scene.json
+++ b/schemas/scene.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/jbltx/ugas/schemas/scene.json",
+  "title": "Scene Composition Schema",
+  "description": "Based on UGAS Specification %%UGAS_VERSION%% - Section 18",
+  "type": "object",
+  "required": [
+    "Name",
+    "Placements"
+  ],
+  "properties": {
+    "Name": {
+      "type": "string",
+      "description": "Unique scene identifier"
+    },
+    "Extends": {
+      "type": "array",
+      "description": "Names of parent scenes this scene composes on top of, additively",
+      "items": {
+        "type": "string"
+      }
+    },
+    "Placements": {
+      "type": "array",
+      "description": "Gameplay Controller instances placed into the world",
+      "items": {
+        "type": "object",
+        "required": [
+          "Controller"
+        ],
+        "properties": {
+          "Controller": {
+            "type": "string",
+            "description": "Name of the GameplayControllerConfig to instantiate"
+          },
+          "InstanceId": {
+            "type": "string",
+            "description": "Stable identity for this instance, used as the persistence key"
+          },
+          "Position": {
+            "type": "array",
+            "description": "World position as x, y, z",
+            "items": {
+              "type": "number"
+            }
+          },
+          "Rotation": {
+            "type": "array",
+            "description": "World rotation as a quaternion x, y, z, w",
+            "items": {
+              "type": "number"
+            }
+          },
+          "StartupTags": {
+            "type": "array",
+            "description": "Tags granted to the instance on spawn",
+            "items": {
+              "type": "string"
+            }
+          },
+          "StartupEffects": {
+            "type": "array",
+            "description": "Effects applied to the instance on spawn",
+            "items": {
+              "type": "string"
+            }
+          },
+          "AttributeOverrides": {
+            "type": "object",
+            "description": "Base value overrides applied after the controller defaults",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "Enabled": {
+            "type": "boolean",
+            "description": "Whether the instance spawns active (default true)"
+          }
+        }
+      }
+    },
+    "Regions": {
+      "type": "array",
+      "description": "Standing zones active while the scene is loaded",
+      "items": {
+        "type": "object",
+        "required": [
+          "Name"
+        ],
+        "properties": {
+          "Name": {
+            "type": "string",
+            "description": "Region identifier"
+          },
+          "Shape": {
+            "type": "string",
+            "description": "Volume shape",
+            "enum": [
+              "Sphere",
+              "Box",
+              "Capsule"
+            ]
+          },
+          "Position": {
+            "type": "array",
+            "description": "Region origin as x, y, z",
+            "items": {
+              "type": "number"
+            }
+          },
+          "Radius": {
+            "type": "number",
+            "description": "Sphere or capsule radius"
+          },
+          "GrantedTags": {
+            "type": "array",
+            "description": "Tags granted to occupants while inside the region",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "SpawnPoints": {
+      "type": "array",
+      "description": "Named poses for dynamic spawning at runtime",
+      "items": {
+        "type": "object",
+        "required": [
+          "Name"
+        ],
+        "properties": {
+          "Name": {
+            "type": "string",
+            "description": "Spawn point identifier"
+          },
+          "Position": {
+            "type": "array",
+            "description": "Spawn position as x, y, z",
+            "items": {
+              "type": "number"
+            }
+          },
+          "Rotation": {
+            "type": "array",
+            "description": "Spawn rotation as a quaternion x, y, z, w",
+            "items": {
+              "type": "number"
+            }
+          },
+          "Tags": {
+            "type": "array",
+            "description": "Classification tags for spawn selection",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "Metadata": {
+      "type": "object",
+      "description": "Non-normative authoring metadata",
+      "additionalProperties": true
+    }
+  }
+}

--- a/schemas/scene.yaml
+++ b/schemas/scene.yaml
@@ -1,0 +1,119 @@
+# Scene Composition Schema Definition
+# Based on UGAS Specification %%UGAS_VERSION%% - Section 18
+
+type: object
+required:
+  - Name
+  - Placements
+properties:
+  Name:
+    type: string
+    description: Unique scene identifier
+  Extends:
+    type: array
+    description: Names of parent scenes this scene composes on top of, additively
+    items:
+      type: string
+  Placements:
+    type: array
+    description: Gameplay Controller instances placed into the world
+    items:
+      type: object
+      required:
+        - Controller
+      properties:
+        Controller:
+          type: string
+          description: Name of the GameplayControllerConfig to instantiate
+        InstanceId:
+          type: string
+          description: Stable identity for this instance, used as the persistence key
+        Position:
+          type: array
+          description: World position as x, y, z
+          items:
+            type: number
+        Rotation:
+          type: array
+          description: World rotation as a quaternion x, y, z, w
+          items:
+            type: number
+        StartupTags:
+          type: array
+          description: Tags granted to the instance on spawn
+          items:
+            type: string
+        StartupEffects:
+          type: array
+          description: Effects applied to the instance on spawn
+          items:
+            type: string
+        AttributeOverrides:
+          type: object
+          description: Base value overrides applied after the controller defaults
+          additionalProperties:
+            type: number
+        Enabled:
+          type: boolean
+          description: Whether the instance spawns active (default true)
+  Regions:
+    type: array
+    description: Standing zones active while the scene is loaded
+    items:
+      type: object
+      required:
+        - Name
+      properties:
+        Name:
+          type: string
+          description: Region identifier
+        Shape:
+          type: string
+          description: Volume shape
+          enum:
+            - Sphere
+            - Box
+            - Capsule
+        Position:
+          type: array
+          description: Region origin as x, y, z
+          items:
+            type: number
+        Radius:
+          type: number
+          description: Sphere or capsule radius
+        GrantedTags:
+          type: array
+          description: Tags granted to occupants while inside the region
+          items:
+            type: string
+  SpawnPoints:
+    type: array
+    description: Named poses for dynamic spawning at runtime
+    items:
+      type: object
+      required:
+        - Name
+      properties:
+        Name:
+          type: string
+          description: Spawn point identifier
+        Position:
+          type: array
+          description: Spawn position as x, y, z
+          items:
+            type: number
+        Rotation:
+          type: array
+          description: Spawn rotation as a quaternion x, y, z, w
+          items:
+            type: number
+        Tags:
+          type: array
+          description: Classification tags for spawn selection
+          items:
+            type: string
+  Metadata:
+    type: object
+    description: Non-normative authoring metadata
+    additionalProperties: true

--- a/scripts/compare_schema_definitions.py
+++ b/scripts/compare_schema_definitions.py
@@ -27,6 +27,7 @@ SCHEMA_PAIRS: Dict[str, Tuple[str, str]] = {
     ),
     "input_mapping": ("schemas/input_mapping.json", "schemas/input_mapping.yaml"),
     "input_modifier": ("schemas/input_modifier.json", "schemas/input_modifier.yaml"),
+    "scene": ("schemas/scene.json", "schemas/scene.yaml"),
 }
 
 ROOT_METADATA_KEYS = {"$schema", "$id", "title", "description"}

--- a/scripts/validate_schema_examples.py
+++ b/scripts/validate_schema_examples.py
@@ -24,6 +24,7 @@ SCHEMA_FILES = {
     "input_action_set": "schemas/input_action_set.json",
     "input_mapping": "schemas/input_mapping.json",
     "input_modifier": "schemas/input_modifier.json",
+    "scene": "schemas/scene.json",
 }
 
 SCHEMA_SUFFIXES = {
@@ -37,6 +38,7 @@ SCHEMA_SUFFIXES = {
     "/schemas/input_action_set.json": "input_action_set",
     "/schemas/input_mapping.json": "input_mapping",
     "/schemas/input_modifier.json": "input_modifier",
+    "/schemas/scene.json": "scene",
 }
 
 


### PR DESCRIPTION
## What
Adds the authorable, machine-validatable **`scene` schema** for Scene Composition (§18, merged in #85) — the second increment of roadmap #4.

- **`schemas/scene.{json,yaml}`** twins — a `Scene`: `Name` + `Placements` (`Controller`, `InstanceId`, `Position`/`Rotation`, `StartupTags`, `StartupEffects`, `AttributeOverrides`, `Enabled`), `Regions` (§17.4 zones), `SpawnPoints`, `Extends` (composition), and `Metadata`.
- Registered with **`compare_schema_definitions.py`** (JSON↔YAML equivalence) and **`validate_schema_examples.py`** (`SCHEMA_FILES` + `SCHEMA_SUFFIXES`). The JSON twin was generated from the YAML, so the structures are equivalent by construction.
- **`schemas/examples/arena_scene.yaml`** — a worked scene: a player + two enemies (one with an `AttributeOverrides` Health tweak), a lava-pit hazard `Region` granting `Zone.Hazard.Fire`, and a player respawn `SpawnPoint`.

## Verification
- `compare_schema_definitions.py` — schema equivalence check **passed** (now includes `scene`).
- `validate_schema_examples.py` — **259/259** snippets (258 + the arena example validating against the scene schema).

**minor** changeset. Completes the §18 authoring surface; the `ugas-unity` `SceneLoader` reference impl and harness scene-authoring are the remaining #4 follow-ups.