### PR TITLE
docs: harness-eval follow-ups — periodic-clamp caveat (§9.3) + task-subset & offline-spec skill notes

### DIFF
--- a/.changeset/spec-periodic-clamp-note.md
+++ b/.changeset/spec-periodic-clamp-note.md
@@ -1,0 +1,5 @@
+---
+'ugas': patch
+---
+
+[Clarified] §9.3 Periodic Execution: each periodic execution applies independently to the Base Value and is clamped on its own (§5.4), so multiple periodic (or Instant) Effects on the same clamped Attribute clamp *after each execution* — not over their net sum — making the result order-sensitive at a bound. Adds a worked regen-vs-poison example, a deterministic-ordering recommendation for reproducibility, and designer guidance (combine opposing periodics into one net-magnitude Effect, or clamp on read).

--- a/.claude/skills/gameplay-creator-assistant/SKILL.md
+++ b/.claude/skills/gameplay-creator-assistant/SKILL.md
@@ -59,6 +59,12 @@ Schema `<type>` is one of: `gameplay_controller`, `attribute`, `attribute_set`,
 and every genre pack at once — prefer it over many small fetches. If it isn't published yet
 for this version, fetch the spec once, then the specific schemas and the one pack you need.
 
+**Offline fallback.** The published docs are *generated from* the `jbltx/ugas` repository. If the
+network is unavailable and a checkout of that repo is at hand, read its working tree directly — `spec/`
+(the AsciiDoc source), `schemas/*.json` + `schemas/*.yaml` (the validation schemas), and `genres/<pack>/`
+(the packs) are the source of truth. Match the checkout's version (tag/branch) to `UGAS_VERSION` so what
+you author lines up with the `$schema` id you stamp.
+
 **`$schema` on the files you write.** Every entity you emit into the consumer's project must
 carry the concrete, version-pinned schema id so their tooling can validate it:
 

--- a/.claude/skills/ugas-harness/SKILL.md
+++ b/.claude/skills/ugas-harness/SKILL.md
@@ -116,6 +116,12 @@ Rules that keep verification honest:
   scenario's result is reproducible — otherwise it isn't an oracle.
 - `Object` is ambiguous in `eval`; use `UnityEngine.Object.DestroyImmediate` and clean up spawned
   GameObjects/SOs.
+- **The reference task factory models a *subset* of ability tasks.** `WaitDelay` (honors `Duration`),
+  `ApplyEffectToOwner`, `RemoveEffectFromOwner`, and `ApplyEffectToActorsInRadius` execute; other
+  authored types (`WaitInputRelease`, `PlayMontage`, `WaitGameplayEvent`) fall back to a **NoOp** that
+  completes immediately. So don't infer a mechanic works from "the ability activated" — when its verb is
+  an unmodeled task, that task did *nothing*. Verify an ability-driven mechanic either by confirming its
+  task type is modeled, or by **applying its payload Effect(s) directly** and asserting the state change.
 
 ## Compose a scene (§18)
 
@@ -156,9 +162,16 @@ On failure, read the eval output and localize:
 - **Missing seam** → the mechanic needs an `ExecCalc_*` execution the consumer implements; note it
   as a seam, not a failure.
 
+Before flagging a runtime gap, rule out two **known-correct-but-surprising** behaviors: (1) a mechanic
+whose ability verb is an unmodeled task silently no-ops (see the task-factory caveat above) — assert on
+the payload directly; (2) **periodic effects on a clamped resource clamp *after each execution*, not
+over their net sum** (§9.3), so stacked regen/decay (or boost/drag on a bounded speed) is order-sensitive
+at a bound — an "off" survival/racing number is often this, not a bug.
+
 ## Prerequisites & environment
 
-- **Author/Validate** need only the fetched spec + schemas (network), like the authoring skills.
+- **Author/Validate** need only the spec + schemas — fetched from the docs site, or read from a local
+  `jbltx/ugas` checkout when offline (see the authoring skills' offline fallback).
 - **Run/Observe** need a **Unity project with `ugas-unity`** and the **`unity-tools` server**
   running (the editor open on that project). Target it with `--project-path`. If it's absent, do
   the Author/Validate stages, produce the eval-sim scenarios as ready-to-run C#, and tell the user

--- a/.claude/skills/ugas-schema-author/SKILL.md
+++ b/.claude/skills/ugas-schema-author/SKILL.md
@@ -72,6 +72,11 @@ There are three duration policies:
 Read `references/schemas.md` for the full schema definitions. Always refer to it when
 generating entity files — never guess at field names or allowed values.
 
+> The schema definitions are **bundled** in `references/schemas.md`, so authoring and validation
+> work fully offline — the `$schema` URL you stamp is a canonical *identifier*, not a runtime fetch.
+> If you need spec prose beyond the schemas (mechanic semantics, section references), read `spec/`
+> from a local `jbltx/ugas` checkout matched to `%%UGAS_VERSION%%`.
+
 ## Authoring workflow
 
 When the user asks you to create a gameplay entity:

--- a/spec/part-2-core-components/09-gameplay-effects.adoc
+++ b/spec/part-2-core-components/09-gameplay-effects.adoc
@@ -119,6 +119,16 @@ Modifiers:
       Value: -5.0  # 5 damage per second
 ----
 
+[NOTE]
+.Periodic execution over a clamped Attribute
+====
+Each periodic execution is an independent Instant application to the Base Value (§5.2) and is therefore subject to the Attribute's bounds (§5.4) *on its own*. When more than one periodic (or Instant) Effect modifies the same clamped Attribute, the bound is applied *after each execution* — never once over their net sum. At a bound the result is consequently order-sensitive and generally differs from summing the deltas and clamping once.
+
+_Example:_ `Health` is clamped to `[0, 100]` and currently `100`. In one tick a `+10` regeneration and a `−30` poison both execute. Regen first: `min(100, 100+10)=100`, then `100−30=70`. Poison first: `100−30=70`, then `min(100, 70+10)=80`. Summing-then-clamping would give `min(100, 100+10−30)=80`. The three disagree only because a bound is reached mid-sequence.
+
+Implementations SHOULD execute a tick's due periodic executions in a deterministic, documented order so that a scenario is reproducible. To make opposing periodics commute at a bound, model them as a single net-magnitude periodic Effect, or leave the Attribute unclamped and clamp on read.
+====
+
 ==== 9.4 Modifier Specification
 
 ===== 9.4.1 Operations


### PR DESCRIPTION
Documentation-only follow-ups from the **real-world harness evaluation** — finding **F4**, plus **F2's documentation half**. No runtime or schema changes; `validate_schema_examples.py` still green (259 snippets).

## F4 — periodic execution over a clamped attribute (spec §9.3)
The eval's survival build hit a genuinely surprising (but correct) behavior: two periodic effects on the same clamped resource (regen + decay) compose via **per-execution clamping**, not net arithmetic. Added a `NOTE` to §9.3 that makes this explicit:
- each periodic execution is an independent Instant application to the Base Value, clamped on its own (§5.4);
- so the bound is applied *after each execution*, not over the net sum → **order-sensitive at a bound**;
- worked regen-vs-poison example (regen-first `70` vs poison-first `80` vs sum-then-clamp `80`);
- a `SHOULD` for deterministic execution order (reproducibility) + designer guidance (one net-magnitude periodic, or clamp on read).

## F2 doc half + F4 watch-for (`ugas-harness` skill)
- The reference **task factory models only a subset** of ability tasks — `WaitDelay`, `ApplyEffectToOwner`, `RemoveEffectFromOwner`, `ApplyEffectToActorsInRadius` execute; `WaitInputRelease`/`PlayMontage`/`WaitGameplayEvent` fall back to `NoOp`. Added a verification rule: don't infer a mechanic works from "the ability activated" — verify ability verbs via their payload effects, or confirm the type is modeled.
- Added a "rule these out before flagging a runtime gap" note to **Iterate** covering the unmodeled-task no-op and the F4 periodic-clamp behavior.

## Offline-spec fallback (authoring skills)
- `gameplay-creator-assistant`: when the docs-site fetch is unavailable, read `spec/`, `schemas/`, `genres/` from a local `jbltx/ugas` checkout (the source the docs are generated from), matched to `UGAS_VERSION`.
- `ugas-schema-author`: made explicit that its schema defs are **bundled** (`references/schemas.md`) so authoring/validation already work offline; the `$schema` URL is a stamped identifier, not a fetch; point to a local checkout for spec prose.
- `ugas-harness`: Author/Validate prerequisites now name the offline path.

Changeset: `ugas` **patch** (spec clarification).