### PR TITLE
fix(genres): strategy pack — author auto-attack/area-strike onto modeled ability tasks

### DIFF
--- a/.changeset/strategy-pack-modeled-tasks.md
+++ b/.changeset/strategy-pack-modeled-tasks.md
@@ -1,0 +1,5 @@
+---
+'ugas': patch
+---
+
+[Changed] Strategy genre pack — re-author `GA_AutoAttack` and `GA_AreaStrike` onto the modeled ability tasks. Auto-attack now uses `ApplyEffectToTarget` (nearest `Faction.Hostile` within `MaxRange`) and area-strike uses `ApplyEffectToActorsInRadius` (blast sparing `Faction.Friendly`), instead of the `WaitTargetData` placeholder — which a reference runtime treats as a no-op, so the abilities hit nobody as shipped. Affiliation (who is `Faction.Hostile`) and ground-target selection remain documented engine seams (§17.2). Surfaced by the real-world strategy harness evaluation.

--- a/genres/strategy/entities/ability_area_strike.yaml
+++ b/genres/strategy/entities/ability_area_strike.yaml
@@ -1,10 +1,10 @@
-# Area strike: a caster ability that spends Energy to hit a target area with Magic damage and a slow.
-# Costs Energy (GE_AreaStrikeCost: a flat Energy subtraction) and goes on a cooldown
-# (GE_AreaStrikeCooldown). On activation it picks a ground location (WaitTargetData), then applies
-# both GE_AreaStrikeDamage (instant Magic damage, via ExecCalc_ArmorMitigation) and GE_Slow to every
-# hostile caught in the blast - so the strike both damages and debuffs. Energy refills over time via
-# the periodic GE_EnergyRegen. GE_AreaStrikeCost and GE_AreaStrikeCooldown are trivial and referenced
-# by name rather than shipped as files.
+# Area strike: a caster ability that spends Energy to hit an area with Magic damage and a slow. Costs
+# Energy (GE_AreaStrikeCost: a flat Energy subtraction) and goes on a cooldown (GE_AreaStrikeCooldown).
+# It applies GE_AreaStrikeDamage (instant Magic damage, via ExecCalc_ArmorMitigation) and GE_Slow to
+# every hostile caught in the blast via ApplyEffectToActorsInRadius — sparing Faction.Friendly. The
+# reference blast is centered on the caster; picking a ground location is an engine targeting seam
+# (§17.2). Energy refills over time via the periodic GE_EnergyRegen. GE_AreaStrikeCost and
+# GE_AreaStrikeCooldown are trivial and referenced by name rather than shipped as files.
 
 $schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
 Name: GA_AreaStrike
@@ -19,16 +19,16 @@ Tags:
 Cost: GE_AreaStrikeCost
 Cooldown: GE_AreaStrikeCooldown
 Tasks:
-  - Type: WaitTargetData
-    Params:
-      TargetingMethod: GroundLocation
-      Radius: 4.0
-  - Type: ApplyEffectToTarget
+  - Type: ApplyEffectToActorsInRadius
     Params:
       EffectClass: GE_AreaStrikeDamage
-  - Type: ApplyEffectToTarget
+      Radius: 4.0
+      IgnoreTargetsWithTag: Faction.Friendly
+  - Type: ApplyEffectToActorsInRadius
     Params:
       EffectClass: GE_Slow
+      Radius: 4.0
+      IgnoreTargetsWithTag: Faction.Friendly
 Metadata:
   DisplayName: Area Strike
   Description: Spend energy to blast a target area with magic damage and a slowing field

--- a/genres/strategy/entities/ability_auto_attack.yaml
+++ b/genres/strategy/entities/ability_auto_attack.yaml
@@ -4,7 +4,9 @@
 # Armor.Class.* tag. Paced by a per-attack cooldown (GE_AttackCooldown, duration = 1 / AttackSpeed)
 # rather than a resource cost. Blocked while the unit is still constructing or cloaked. The
 # "target within AttackRange" check is activation logic (an attribute comparison, which cannot be an
-# activation tag), so WaitTargetData acquires the in-range target before the damage is applied.
+# activation tag), so ApplyEffectToTarget self-acquires the nearest in-range hostile before applying the
+# damage. Affiliation (which units are Faction.Hostile to this attacker) is the engine team model's job —
+# §17.2 defers affiliation to the title, which tags opponents Faction.Hostile per the registry.
 
 $schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
 Name: GA_AutoAttack
@@ -19,13 +21,11 @@ Tags:
     - Unit.State.Cloaked
 Cooldown: GE_AttackCooldown
 Tasks:
-  - Type: WaitTargetData
-    Params:
-      TargetingMethod: NearestEnemyInRange
-      MaxRange: 7.0
   - Type: ApplyEffectToTarget
     Params:
       EffectClass: GE_UnitDamage
+      MaxRange: 7.0
+      RequireTag: Faction.Hostile
 Metadata:
   DisplayName: Auto Attack
   Description: Fire the unit's weapon at the nearest enemy within range


### PR DESCRIPTION
The strategy harness eval found `GA_AutoAttack`/`GA_AreaStrike` were authored against `WaitTargetData` (a placeholder the reference runtime treats as a **NoOp**) with no range/tag filter on the follow-on task — so **as shipped the abilities hit nobody**. Re-authored onto the modeled tasks:

- **GA_AutoAttack** → a single `ApplyEffectToTarget` that self-acquires the nearest `Faction.Hostile` within `MaxRange: 7` and applies `GE_UnitDamage`.
- **GA_AreaStrike** → two `ApplyEffectToActorsInRadius` tasks (`GE_AreaStrikeDamage` then `GE_Slow`) over `Radius: 4`, sparing `Faction.Friendly`.

Affiliation (which units are `Faction.Hostile` to the source) and ground-target selection remain documented engine seams (§17.2). Both files validate against `gameplay_ability.json`; example validator green (259 snippets). Changeset: `ugas` **patch**.