### PR TITLE
fix(genres): combat pack — author normals/special onto the modeled ApplyEffectToTarget

### DIFF
--- a/.changeset/combat-pack-modeled-tasks.md
+++ b/.changeset/combat-pack-modeled-tasks.md
@@ -1,0 +1,5 @@
+---
+'ugas': patch
+---
+
+[Changed] Combat genre pack — re-author `GA_LightAttack`, `GA_HeavyAttack`, and `GA_Special` onto the modeled `ApplyEffectToTarget` ability task. Each normal previously resolved its hit as `[WaitDelay, WaitTargetData(MeleeSweep), ApplyEffectToTarget{EffectClass only}, WaitDelay]` — but `WaitTargetData` is an unmodeled task a reference runtime treats as a no-op, and the follow-on `ApplyEffectToTarget` carried no `MaxRange`, so the attacks connected with nobody as shipped. They now use `ApplyEffectToTarget` with `MaxRange` + `RequireTag: Team.Hostile` (nearest hostile in range), dropping `WaitTargetData`; the `WaitDelay` startup/recovery frames are unchanged. High/mid/low hitzone guard rules and which fighter is `Team.Hostile` remain documented engine targeting seams (§17.2). Surfaced by the real-world fighting harness evaluation (same class as the strategy-pack fix).

--- a/genres/combat/entities/ability_heavy_attack.yaml
+++ b/genres/combat/entities/ability_heavy_attack.yaml
@@ -1,9 +1,11 @@
 # Heavy attack: the slow, high-damage normal and the combo's cancel target. Longer startup and
 # recovery than the light, but it deals far more damage, poise damage, and guard damage (all carried
-# by GE_MeleeDamage and resolved by ExecCalc_MeleeResolution). Its CancelAbilitiesWithTags lists
-# Ability.Type.Light, so activating the heavy during a light attack's recovery CANCELS that light -
-# this is the light->heavy combo cancel expressed purely with tags. Cannot start while in hitstun,
-# blockstun, staggered, or blocking.
+# by GE_MeleeDamage and resolved by ExecCalc_MeleeResolution). A WaitDelay startup gates the hitbox,
+# then ApplyEffectToTarget applies GE_MeleeDamage to the nearest Team.Hostile within MaxRange (the
+# modeled melee-hit path; hitzone/guard-height is an engine targeting seam, §17.2), then a WaitDelay
+# recovery. Its CancelAbilitiesWithTags lists Ability.Type.Light, so activating the heavy during a light
+# attack's recovery CANCELS that light - the light->heavy combo cancel expressed purely with tags.
+# Cannot start while in hitstun, blockstun, staggered, or blocking.
 
 $schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
 Name: GA_HeavyAttack
@@ -26,14 +28,11 @@ Tasks:
   - Type: WaitDelay
     Params:
       Duration: 0.2
-  - Type: WaitTargetData
-    Params:
-      TargetingMethod: MeleeSweep
-      MaxRange: 1.8
-      Hitzone: Hitzone.High
   - Type: ApplyEffectToTarget
     Params:
       EffectClass: GE_MeleeDamage
+      MaxRange: 1.8
+      RequireTag: Team.Hostile
   - Type: WaitDelay
     Params:
       Duration: 0.35

--- a/genres/combat/entities/ability_light_attack.yaml
+++ b/genres/combat/entities/ability_light_attack.yaml
@@ -1,9 +1,11 @@
-# Light attack: the fast combo starter. Quick startup, short recovery, low damage. Walks the
-# three frame phases (Combat.Move.Startup -> Active -> Recovery) via its ActivationOwnedTags and the
-# task sequence, applying GE_MeleeDamage to the target during the Active window. It owns
-# Combat.Move.Recovery during its tail, which is exactly the tag GA_HeavyAttack's
-# CancelAbilitiesWithTags cancels - so a heavy buffered during light recovery interrupts it,
-# the basic combo cancel. Cannot start while in hitstun, blockstun, staggered, or blocking.
+# Light attack: the fast combo starter. Quick startup, short recovery, low damage. A WaitDelay startup
+# gates the hitbox, then ApplyEffectToTarget applies GE_MeleeDamage to the nearest Team.Hostile within
+# MaxRange (the modeled melee-hit path; a reference runtime treats WaitTargetData as a no-op, so the
+# sweep target is acquired by ApplyEffectToTarget itself), then a WaitDelay recovery. Which fighter is
+# Team.Hostile, and high/mid/low hitzone guard rules, are engine targeting seams (§17.2). It owns
+# Combat.Move.Recovery during its tail, which is exactly the tag GA_HeavyAttack's CancelAbilitiesWithTags
+# cancels - so a heavy during light recovery interrupts it, the basic combo cancel. Cannot start while in
+# hitstun, blockstun, staggered, or blocking.
 
 $schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
 Name: GA_LightAttack
@@ -24,14 +26,11 @@ Tasks:
   - Type: WaitDelay
     Params:
       Duration: 0.08
-  - Type: WaitTargetData
-    Params:
-      TargetingMethod: MeleeSweep
-      MaxRange: 1.5
-      Hitzone: Hitzone.Mid
   - Type: ApplyEffectToTarget
     Params:
       EffectClass: GE_MeleeDamage
+      MaxRange: 1.5
+      RequireTag: Team.Hostile
   - Type: WaitDelay
     Params:
       Duration: 0.18

--- a/genres/combat/entities/ability_special.yaml
+++ b/genres/combat/entities/ability_special.yaml
@@ -3,8 +3,9 @@
 # empty gauge - the cost gate is what enforces "need meter", no explicit check tag required. During
 # its cinematic super-freeze startup it owns Combat.Move.Startup and uses BlockAbilitiesWithTags to
 # lock out the user's OWN normals (Light/Heavy/Block) for the freeze - committing the player to the
-# super animation (an owner-scoped self-lock, not anything applied to the opponent) - then sweeps a high-damage hit
-# that applies GE_MeleeDamage. Blocked while in hitstun, blockstun, or staggered. Goes on a long
+# super animation (an owner-scoped self-lock, not anything applied to the opponent) - then ApplyEffectToTarget
+# applies GE_MeleeDamage to the nearest Team.Hostile within MaxRange (the modeled melee-hit path; hitzone
+# is an engine targeting seam, §17.2). Blocked while in hitstun, blockstun, or staggered. Goes on a long
 # cooldown (GE_SpecialCooldown) so it cannot be chained even with meter to spare.
 
 $schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
@@ -30,14 +31,11 @@ Tasks:
   - Type: WaitDelay
     Params:
       Duration: 0.5
-  - Type: WaitTargetData
-    Params:
-      TargetingMethod: MeleeSweep
-      MaxRange: 2.5
-      Hitzone: Hitzone.Mid
   - Type: ApplyEffectToTarget
     Params:
       EffectClass: GE_MeleeDamage
+      MaxRange: 2.5
+      RequireTag: Team.Hostile
   - Type: WaitDelay
     Params:
       Duration: 0.4


### PR DESCRIPTION
## What

The combat genre pack's `GA_LightAttack` / `GA_HeavyAttack` / `GA_Special` resolved their hit as `[WaitDelay, WaitTargetData(MeleeSweep), ApplyEffectToTarget{EffectClass only}, WaitDelay]`. But `WaitTargetData` is an **unmodeled** ability task (a reference runtime treats it as a no-op — the intended sweep/hitzone/`MaxRange` targeting is dropped), and the follow-on `ApplyEffectToTarget` carried **no `MaxRange`** → range 0, so the normals **connected with nobody as shipped**.

Surfaced by the real-world **fighting harness eval** (finding F2) — same class as the strategy-pack fix (#90).

## Change

Re-authored each normal/special onto the modeled `ApplyEffectToTarget` (nearest `Team.Hostile` within `MaxRange`), dropping `WaitTargetData`:

```yaml
- Type: ApplyEffectToTarget
  Params:
    EffectClass: GE_MeleeDamage
    MaxRange: 1.5          # 1.8 heavy, 2.5 special
    RequireTag: Team.Hostile
```

The `WaitDelay` startup/recovery frames are unchanged, so frame-data timing is preserved. High/mid/low **hitzone** guard rules and which fighter is `Team.Hostile` remain documented **engine targeting seams** (§17.2). Header comments updated to match.

## Verify

`scripts/validate_schema_examples.py` green (259 snippets). The corrected shape is proven to connect in-engine by the fighting eval's `S1` (against the live `ugas-unity` runtime); patch changeset included.