### PR TITLE
fix(genres,spec): rpg-eval follow-ups — basic-attack targeting (F1) + Instant×Multiply base semantics (F2)

### DIFF
--- a/.changeset/instant-multiply-base-semantics.md
+++ b/.changeset/instant-multiply-base-semantics.md
@@ -1,0 +1,5 @@
+---
+'ugas': patch
+---
+
+[Changed] Spec §5.2 — define how an Instant effect applies each modifier operation to the Base Value, resolving the previously-undefined Instant × `Multiply` case. An Instant `Multiply` scales the Base Value by `(1 + magnitude)` (the §5.3 signed-bonus convention: `+1.0` doubles, `-0.25` removes 25%), then clamps to the attribute's bounds. The per-operation rules are stated as *total* — an implementation MUST NOT silently drop any operation. A durational (Infinite/HasDuration) effect's `Multiply`/`Divide` remain Current-Value modifiers and are never written to the Base Value, including on the periodic ticks of a periodic durational effect (which apply only `Add`/`AddPost`/`Override` to base). Surfaced by the real-world RPG harness evaluation, where an Instant `Multiply` was a silent no-op.

--- a/.changeset/rpg-pack-basic-attack-modeled.md
+++ b/.changeset/rpg-pack-basic-attack-modeled.md
@@ -1,0 +1,5 @@
+---
+'ugas': patch
+---
+
+[Changed] RPG genre pack — re-author `GA_BasicAttack` onto the modeled `ApplyEffectToTarget`. The shipped attack resolved its hit as `[PlayMontage, WaitGameplayEvent, ApplyEffectToTarget{EffectClass only}]`; a reference runtime treats `PlayMontage`/`WaitGameplayEvent` as no-ops and the range-less `ApplyEffectToTarget` self-acquires within a zero-radius sphere, so the default attack connected with nobody as shipped. It now applies `GE_BasicAttackDamage` to the nearest `Team.Hostile` within `MaxRange` — with new `Team.Friendly`/`Team.Hostile` affiliation tags in the registry (affiliation is engine-assigned per §17.2; the worked-example hero is `Team.Friendly`). `PlayMontage`/`WaitGameplayEvent` remain as documented engine seams for the swing + hit-window. Surfaced by the real-world RPG harness evaluation (same class as the strategy and combat pack fixes).

--- a/genres/rpg/entities/ability_basic_attack.yaml
+++ b/genres/rpg/entities/ability_basic_attack.yaml
@@ -1,4 +1,10 @@
-# Default single-target weapon strike. Free (no cost), short montage, applies weapon damage.
+# Default single-target weapon strike. Free (no cost), short montage, applies weapon damage to the
+# acquired target. PlayMontage / WaitGameplayEvent are engine seams (the montage plays the swing and the
+# hit-window event fires mid-anim); a reference runtime treats them as no-ops. The actual hit is the
+# modeled ApplyEffectToTarget, which needs a MaxRange + a target filter to self-acquire in the reference
+# runtime — it applies GE_BasicAttackDamage to the nearest Team.Hostile in range. Affiliation (who is
+# Team.Hostile) is the engine team model's job (§17.2). A real title supplies the exact victim from the
+# player's target / the montage hit-window instead.
 
 $schema: https://raw.githubusercontent.com/jbltx/ugas/%%UGAS_VERSION%%/schemas/gameplay_ability.json
 Name: GA_BasicAttack
@@ -20,6 +26,8 @@ Tasks:
   - Type: ApplyEffectToTarget
     Params:
       EffectClass: GE_BasicAttackDamage
+      MaxRange: 2.5
+      RequireTag: Team.Hostile
 Metadata:
   DisplayName: Basic Attack
   Description: Strike a single target for weapon damage

--- a/genres/rpg/entities/gameplay_controller.yaml
+++ b/genres/rpg/entities/gameplay_controller.yaml
@@ -45,6 +45,7 @@ OwnedTags:
   - State.Alive
   - State.Combat
   - Class.Barbarian
+  - Team.Friendly
   - Item.Equipped.Weapon
   - Item.Type.Sword
 ReplicationMode: Mixed

--- a/genres/rpg/entities/tag_registry.yaml
+++ b/genres/rpg/entities/tag_registry.yaml
@@ -45,6 +45,16 @@ Tags:
     Description: Target ignores incoming fire damage
     AllowMultiple: false
 
+  # --- Affiliation (engine-assigned; §17.2 defers affiliation to the title) ---
+  # Which actors are hostile to the hero is the engine team model's job; abilities filter targets by
+  # these so a single-target strike acquires an enemy (not the caster or an ally).
+  - Tag: Team.Friendly
+    Description: Same side as the source (the player party); spared by hostile-only targeting
+    AllowMultiple: false
+  - Tag: Team.Hostile
+    Description: An enemy of the source; a valid target for the hero's attacks
+    AllowMultiple: false
+
   # --- Items (granted by equip effects) ---
   - Tag: Item.Equipped.Weapon
     Description: A weapon is equipped in the main hand

--- a/spec/part-2-core-components/05-attributes.adoc
+++ b/spec/part-2-core-components/05-attributes.adoc
@@ -73,6 +73,30 @@ Current Value::
 | Ephemeral (calculated)
 |===
 
+===== Instant Modifiers on the Base Value
+
+An Instant effect applies each of its Modifiers *directly to the Base Value*, in authored order,
+according to the operation:
+
+* `Add` / `AddPost` — add the (signed) magnitude to the Base Value.
+* `Override` — set the Base Value to the magnitude.
+* `Multiply` — scale the Base Value by `stem:[(1 + m)]`, the same signed-bonus convention the
+  Current-Value pipeline uses (§5.3): a magnitude of `+1.0` doubles the Base Value, `-0.25` removes 25%.
+  Channel grouping is a Current-Value concept and does not apply to a Base-Value write — each Instant
+  `Multiply` scales the Base Value independently, in authored order.
+
+The result is then clamped to the Attribute's declared bounds. These per-operation rules are *total*: an
+implementation MUST NOT silently drop any operation (a `Multiply` on an Instant effect is a Base-Value
+scale, not a no-op). An Instant `Multiply` with magnitude `0` is the identity (`stem:[times 1]`).
+
+This applies only to *Instant* effects. A durational (Infinite / HasDuration) effect's `Multiply` and
+`Divide` modifiers are Current-Value modifiers (§5.3) and are never written to the Base Value — including
+on the periodic ticks of a periodic durational effect, whose executions apply only `Add` / `AddPost` /
+`Override` to the Base Value (a periodic `Multiply`-to-base would double-count against the effect's own
+Current-Value contribution and compound every tick). A percentage change that must be *permanent* is
+authored as an Instant `Multiply`; a percentage change that lasts *while an effect is active* is a
+durational `Multiply` in the Current-Value pipeline.
+
 ==== 5.3 Modifier Pipeline
 
 The Current Value calculation MUST follow a standardized pipeline to ensure mathematical consistency across implementations.


### PR DESCRIPTION
Two follow-ups from the independent real-world **RPG harness evaluation**.

## F1 — rpg pack `GA_BasicAttack` connected with nobody

Shipped as `[PlayMontage, WaitGameplayEvent, ApplyEffectToTarget{EffectClass only}]`. A reference runtime treats `PlayMontage`/`WaitGameplayEvent` as no-ops, and the range-less `ApplyEffectToTarget` self-acquires within a zero-radius sphere → the genre's default attack hit no one.

- Re-authored `GA_BasicAttack` onto the modeled `ApplyEffectToTarget` — nearest `Team.Hostile` within `MaxRange`.
- Added `Team.Friendly` / `Team.Hostile` affiliation tags (affiliation is engine-assigned, §17.2); the worked-example hero is `Team.Friendly`.
- `PlayMontage` / `WaitGameplayEvent` kept as documented engine seams (the swing + hit-window).
- Same class as the strategy (#90) and combat (#91) pack fixes.

## F2 — spec §5.2: Instant × `Multiply` was undefined (silent no-op in the reference runtime)

Added a normative subsection defining how an Instant effect applies each modifier op to the Base Value:

- `Add`/`AddPost` add, `Override` sets, **`Multiply` scales the Base Value by `(1 + magnitude)`** (the §5.3 signed-bonus convention), then clamps.
- The per-operation rules are **total** — an implementation MUST NOT silently drop any operation.
- A **durational** effect's `Multiply`/`Divide` stay Current-Value modifiers and are never written to base, including on the periodic ticks of a periodic durational effect (which apply only `Add`/`AddPost`/`Override`).

Pairs with the ugas-unity runtime implementation (jbltx/ugas-unity#45). Two `patch` changesets included; `validate_schema_examples.py` green (259 snippets).