### PR TITLE
docs(spec): §9.2 — durations advance in tick time; document the turn-based pattern

### DIFF
--- a/.changeset/durations-are-tick-time.md
+++ b/.changeset/durations-are-tick-time.md
@@ -1,0 +1,5 @@
+---
+'ugas': patch
+---
+
+[Changed] Spec §9.2 — clarify that `HasDuration` timers and periodic intervals (§9.3) advance in the runtime's *tick time*, not a built-in notion of "turn", and document the turn/phase-based authoring pattern: a card battler or tactics game advances effects by one fixed turn-step at end-of-turn (a status authored to last `N` expires after `N` turn-steps) and must NOT also advance them with per-frame time, which would age turn-scoped statuses mid-turn. The unit of a duration is whatever unit the title advances the runtime by — real-time titles pass seconds, turn-based titles pass one step per turn — so the effect model serves both without a separate "turns" concept, provided the title drives a single consistent clock. Surfaced by the real-world no-pack deck-builder harness evaluation (F1).

--- a/spec/part-2-core-components/09-gameplay-effects.adoc
+++ b/spec/part-2-core-components/09-gameplay-effects.adoc
@@ -83,6 +83,18 @@ HasDuration Effects::
 Infinite Effects::
   Modify the Current Value indefinitely until explicitly removed. Classic examples: passive auras, equipment bonuses, persistent status effects.
 
+[NOTE]
+====
+`HasDuration` timers and periodic intervals (§9.3) advance in the runtime's *tick time* — the elapsed
+amount passed to each update — not in any built-in notion of "turn." A **turn- or phase-based title** (a
+card battler, a tactics grid) represents each turn as a discrete advance: it ticks the system by one
+fixed turn-step at end-of-turn — so a status authored to last `N` expires after `N` turn-steps — and it
+does **not** *also* advance those same effects with per-frame time, which would age turn-scoped statuses
+mid-turn. In other words the *unit* of a duration is whatever unit the title advances the runtime by:
+real-time titles pass seconds; turn-based titles pass one step per turn. This keeps the effect model
+usable for both without a separate "turns" concept, but the title MUST drive a single, consistent clock.
+====
+
 ==== 9.3 Periodic Execution
 
 Effects with duration (HasDuration or Infinite) MAY execute periodically:


### PR DESCRIPTION
From the **no-pack deck-builder harness eval** (finding F1). The agent built a turn-based card battler on UGAS and had to represent turns itself; the wrinkle it flagged is that `HasDuration`/periodic timers advance in wall-clock tick time, so a naive author ticking with per-frame `dt` would age turn-scoped statuses mid-turn.

This is a **design boundary, not a runtime bug** — UGAS is real-time by design, and the adopter's turn-driver handles it cleanly. So the fix is documentation: a §9.2 note stating durations advance in the runtime's tick time, and documenting the turn/phase pattern — a card battler or tactics game advances effects by one fixed turn-step at end-of-turn (a status authored to last `N` expires after `N` turn-steps) and must not *also* advance them with per-frame time. The unit of a duration is whatever unit the title advances the runtime by, so the model serves both real-time and turn-based games on one consistent clock.

Pairs with the runtime SetByCaller fix (jbltx/ugas-unity#47, deck-builder F2). `patch` changeset included; `validate_schema_examples.py` green (259 snippets).