### PR TITLE
ci(docs): pin wranglerVersion so an upstream publish cannot break every PR

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -123,6 +123,14 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Pinned deliberately. Unpinned, the action installs whatever `wrangler@4`
+          # currently resolves to, so a broken upstream publish breaks every PR here
+          # within seconds of hitting npm — which is exactly what happened on
+          # 2026-08-11: wrangler 4.121.0 shipped exact-pinning
+          # `miniflare@5.20260804.1-alpha`, a version that was never published, so
+          # `npm i wrangler@4` failed with ETARGET. Bump this after checking the
+          # release resolves and is provenance-signed.
+          wranglerVersion: "4.120.1"
           command: pages deploy dist --project-name=ugas --branch=${{ steps.ver.outputs.branch }}
 
       - name: Post preview URL as PR comment


### PR DESCRIPTION
Pins `wranglerVersion` in the docs preview deploy so a broken upstream npm release cannot take down CI on every open PR.

## What happened

`cloudflare/wrangler-action@v4` has no version pin, so it installs whatever `wrangler@4` resolves to at run time. On 2026-08-11 that broke:

| | |
|---|---|
| `wrangler@4.121.0` published | `19:25:24.780Z` |
| our `preview-docs` run reached the deploy step | `19:25:53Z` — **29 seconds later** |
| result | `npm error code ETARGET` / `No matching version found for miniflare@5.20260804.1-alpha` |

`wrangler@4.121.0` exact-pins `miniflare: 5.20260804.1-alpha`. Published miniflare alphas stop at `5.20260804.0-alpha` — the `.1` was never published, so `npm i wrangler@4` cannot resolve. Every build and artifact-verification step in that run was green; only the deploy step failed.

## This is not a registry compromise

That was the first read, and worth ruling out explicitly given how much supply-chain abuse has been going around. The registry says otherwise:

| check | result |
|---|---|
| `wrangler@4.121.0` present in registry | **yes**, and still the `latest` dist-tag |
| `time.unpublished` on `wrangler` | absent |
| `time.unpublished` on `miniflare` | absent — its registry doc was not even modified that day |
| `dist.signatures` | present |
| `dist.attestations` (provenance) | present |
| publisher | `GitHub Actions <npm-oidc-no-reply@github.com>`, `trustedPublisher: github` (OIDC) |

npm records unpublications under `time.unpublished`; neither package has one. And 4.121.0 carries provenance attestation via OIDC trusted publishing, which someone with stolen maintainer credentials could not produce. `workerd@1.20260804.1` published fine while the miniflare bump did not — a partial monorepo release, not a takedown.

### The alarming-looking log line is a red herring

```
npm error npx canceled due to missing packages and no YES option: ["wrangler@4.121.0"]
```

This is the action's own `npx --no-install wrangler --version` probe for an already-installed binary. `--no-install` forbids fetching, so on a fresh runner it always fails and the action proceeds to install. **It appears verbatim in runs that succeed** — e.g. the passing run 20 minutes earlier logged the identical message for `wrangler@4.120.1`, then deployed fine. It does not mean the package is missing from the registry.

## The change

```yaml
wranglerVersion: "4.120.1"
```

with a comment recording why, so the next person to bump it knows what to check.

All eight of `4.120.1`'s exact-pinned dependencies verified present in the registry:

```
OK  @cloudflare/kv-asset-handler@0.5.0   OK  miniflare@5.20260804.0-alpha
OK  @cloudflare/unenv-preset@2.16.1      OK  path-to-regexp@6.3.0
OK  blake3-wasm@2.1.5                    OK  unenv@2.0.0-rc.24
OK  esbuild@0.28.1                       OK  workerd@1.20260804.1
```

Beyond unblocking CI, this means a future compromised release is not picked up silently — bumping becomes a reviewed change rather than an implicit one.

## Scope

`preview-docs.yml` only. `publish-docs.yml` deploys by pushing to the `docs` branch and never invokes wrangler, so it was unaffected.

## Worth considering separately

The actions themselves are pinned to mutable tags (`cloudflare/wrangler-action@v4`, `actions/checkout@v6`, `actions/github-script@v9`). Pinning those to commit SHAs is the stronger supply-chain control, since a tag can be repointed at new code. That is a repo-wide policy change across all four workflows, so I have kept it out of this PR — say the word if you want it.

No changeset: CI-only, no effect on the published package.
